### PR TITLE
feat: add MIT license and improve mobile UI

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 cdilga
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/src/components/mobile/BottomTabBar.css
+++ b/src/components/mobile/BottomTabBar.css
@@ -90,7 +90,7 @@
   -webkit-tap-highlight-color: transparent;
 
   /* Ensure minimum touch target */
-  min-height: 40px;
+  min-height: 44px;
 }
 
 /* Technical grid background on active */
@@ -121,7 +121,7 @@
 
 /* Icon styling */
 .tab-icon {
-  font-size: 17px;
+  font-size: 19px;
   line-height: 1;
   transition: all var(--mobile-transition-fast);
   font-style: normal;

--- a/src/components/mobile/MobileLayout.css
+++ b/src/components/mobile/MobileLayout.css
@@ -38,8 +38,8 @@
   --mobile-status-stopped: var(--mobile-text-tertiary);
 
   /* Layout metrics - scaled down 15% for mobile (Phase 5 refinement) */
-  --mobile-toolbar-height: 37px;
-  --mobile-tabbar-height: 44px;
+  --mobile-toolbar-height: 40px;
+  --mobile-tabbar-height: 48px;
   --mobile-safe-bottom: env(safe-area-inset-bottom, 0px);
 
   /* Animation timing - precise, mechanical */
@@ -143,8 +143,8 @@
 }
 
 .mobile-menu-btn {
-  width: 32px;
-  height: 32px;
+  width: 36px;
+  height: 36px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -172,9 +172,9 @@
 
 /* Hamburger icon - perfectly centered (Phase 5 fix) */
 .menu-icon {
-  width: 14px;
+  width: 16px;
   height: 2px;
-  background: currentColor;
+  background: var(--mobile-text-primary);
   border-radius: 1px;
   position: relative;
   display: block;
@@ -185,9 +185,9 @@
 .menu-icon::after {
   content: '';
   position: absolute;
-  width: 14px;
+  width: 16px;
   height: 2px;
-  background: currentColor;
+  background: var(--mobile-text-primary);
   border-radius: 1px;
   left: 0;
   transition: all var(--mobile-transition-fast);
@@ -203,6 +203,11 @@
 
 .mobile-menu-btn.active .menu-icon {
   background: transparent;
+}
+
+.mobile-menu-btn.active .menu-icon::before,
+.mobile-menu-btn.active .menu-icon::after {
+  background: var(--mobile-bg-base);
 }
 
 .mobile-menu-btn.active .menu-icon::before {
@@ -331,7 +336,7 @@
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 10px 12px;
+  padding: 12px 14px;
   background: transparent;
   border: none;
   border-bottom: 1px solid var(--mobile-border);
@@ -342,7 +347,7 @@
   text-align: left;
   cursor: pointer;
   transition: all var(--mobile-transition-fast);
-  min-height: 40px;
+  min-height: 44px;
 }
 
 .mobile-menu-item:last-child {
@@ -434,7 +439,7 @@
   align-items: center;
   justify-content: center;
   gap: 3px;
-  height: 48px;
+  height: 52px;
   background: var(--mobile-bg-elevated);
   border: 1px solid var(--mobile-border);
   border-radius: 7px;
@@ -448,7 +453,7 @@
   transition: all var(--mobile-transition-fast);
 
   /* Touch target */
-  min-height: 40px;
+  min-height: 44px;
 }
 
 .sim-btn:disabled {


### PR DESCRIPTION
- Add MIT License file (2026)
- Fix hamburger menu icon display: use explicit color instead of currentColor for better cross-browser compatibility, increase width from 14px to 16px
- Increase mobile touch target sizes for better usability:
  - Toolbar height: 37px → 40px
  - Tab bar height: 44px → 48px
  - Menu button: 32px → 36px
  - Simulation buttons: 48px → 52px
  - Menu items: 40px → 44px
  - Tab icons: 17px → 19px