### PR TITLE
fix: preserve simulation state when resuming from pause

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -114,13 +114,18 @@ export function MainLayout() {
 
   // Simulation control handlers
   const handleRun = useCallback(() => {
-    // Initialize variables from AST before starting
-    const ast = currentASTRef.current;
-    if (ast) {
-      const store = useSimulationStore.getState() as SimulationStoreInterface;
-      initializeVariables(ast, store);
-      runtimeStateRef.current = createRuntimeState(ast);
+    const currentStatus = useSimulationStore.getState().status;
+
+    // Only initialize variables when starting from stopped, not when resuming from paused
+    if (currentStatus === 'stopped') {
+      const ast = currentASTRef.current;
+      if (ast) {
+        const store = useSimulationStore.getState() as SimulationStoreInterface;
+        initializeVariables(ast, store);
+        runtimeStateRef.current = createRuntimeState(ast);
+      }
     }
+
     startSimulation();
   }, [startSimulation]);
 

--- a/src/store/simulation-store.test.ts
+++ b/src/store/simulation-store.test.ts
@@ -31,6 +31,43 @@ describe('simulation-store', () => {
       expect(useSimulationStore.getState().booleans).toEqual({});
       expect(useSimulationStore.getState().integers).toEqual({});
     });
+
+    it('preserves state when pausing and resuming', () => {
+      let store = useSimulationStore.getState();
+
+      // Set up some state
+      store.start();
+      store.setBool('flag', true);
+      store.setInt('counter', 42);
+      store.initTimer('TMR1', 1000);
+      store.setTimerInput('TMR1', true);
+      store.updateTimer('TMR1', 500); // Partially through timing
+
+      // Verify initial state
+      expect(store.getBool('flag')).toBe(true);
+      expect(store.getInt('counter')).toBe(42);
+      expect(store.getTimer('TMR1')?.ET).toBe(500);
+
+      // Pause
+      store.pause();
+      store = useSimulationStore.getState(); // Get fresh state
+      expect(store.status).toBe('paused');
+
+      // State should be preserved during pause
+      expect(store.getBool('flag')).toBe(true);
+      expect(store.getInt('counter')).toBe(42);
+      expect(store.getTimer('TMR1')?.ET).toBe(500);
+
+      // Resume (this is just setting status back to running)
+      store.start();
+      store = useSimulationStore.getState(); // Get fresh state
+      expect(store.status).toBe('running');
+
+      // State should still be preserved after resume
+      expect(store.getBool('flag')).toBe(true);
+      expect(store.getInt('counter')).toBe(42);
+      expect(store.getTimer('TMR1')?.ET).toBe(500);
+    });
   });
 
   describe('boolean variables', () => {


### PR DESCRIPTION
Previously, clicking the Run button would always reinitialize all
variables and runtime state, even when resuming from a paused state.
This caused the simulation to reset instead of continuing from where
it was paused.

Fixed by checking the current simulation status in handleRun and only
initializing variables when starting from 'stopped' state, not when
resuming from 'paused' state.

Also added test case to verify state preservation during pause/resume.