### PR TITLE
Add PropertyDrawer for selected node properties

### DIFF
--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -10,6 +10,7 @@ import { Panel, Group as PanelGroup, Separator as PanelResizeHandle } from 'reac
 import { LadderCanvas } from '../ladder-editor/LadderCanvas';
 import { STEditor } from '../st-editor/STEditor';
 import { VariableWatch } from '../variable-watch/VariableWatch';
+import { PropertyDrawer } from '../property-drawer';
 import { ProgramSelector } from '../program-selector';
 import { ErrorPanel } from '../error-panel';
 import { TutorialLightbulb } from '../onboarding';
@@ -385,13 +386,18 @@ export function MainLayout() {
           </PanelGroup>
         </div>
 
-        {/* Variable Watch Panel (includes Properties tab) */}
+        {/* Variable Watch Panel */}
         <VariableWatch
           collapsed={watchPanelCollapsed}
           onToggleCollapse={() => setWatchPanelCollapsed(!watchPanelCollapsed)}
-          selectedNode={selectedNode}
         />
       </div>
+
+      {/* Property Drawer - slides in when a node is selected */}
+      <PropertyDrawer
+        selectedNode={selectedNode}
+        onClose={() => setSelectedNode(null)}
+      />
 
       {/* Error Panel */}
       <ErrorPanel

--- a/src/components/property-drawer/PropertyDrawer.css
+++ b/src/components/property-drawer/PropertyDrawer.css
@@ -1,0 +1,397 @@
+/**
+ * Property Drawer Styles
+ *
+ * Industrial/technical aesthetic inspired by control panels and circuit diagrams.
+ * Slides in from the right edge with smooth animations.
+ */
+
+/* =============================================================================
+   CSS Variables
+   ============================================================================= */
+
+.property-drawer {
+  --drawer-width: 260px;
+  --drawer-bg: #1a1d24;
+  --drawer-border: #2a3140;
+  --drawer-accent: #4da6ff;
+  --drawer-accent-dim: rgba(77, 166, 255, 0.15);
+  --drawer-text: #c8cdd5;
+  --drawer-text-dim: #6b7280;
+  --drawer-surface: #232830;
+  --drawer-glow: rgba(77, 166, 255, 0.08);
+
+  /* Transition timing */
+  --drawer-transition: 200ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* =============================================================================
+   Backdrop
+   ============================================================================= */
+
+.property-drawer-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  background: transparent;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--drawer-transition);
+}
+
+.property-drawer-backdrop.visible {
+  pointer-events: auto;
+  opacity: 1;
+  background: rgba(0, 0, 0, 0.15);
+}
+
+/* =============================================================================
+   Drawer Panel
+   ============================================================================= */
+
+.property-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: var(--drawer-width);
+  z-index: 100;
+
+  display: flex;
+  flex-direction: column;
+
+  background: var(--drawer-bg);
+  border-left: 1px solid var(--drawer-border);
+  box-shadow:
+    -4px 0 20px rgba(0, 0, 0, 0.25),
+    -1px 0 0 var(--drawer-border);
+
+  transform: translateX(100%);
+  opacity: 0;
+  visibility: hidden;
+  transition:
+    transform var(--drawer-transition),
+    opacity var(--drawer-transition),
+    visibility 0ms linear var(--drawer-transition);
+
+  /* Subtle inner glow at top */
+  background-image: linear-gradient(
+    180deg,
+    var(--drawer-glow) 0%,
+    transparent 120px
+  );
+
+  overflow: hidden;
+}
+
+.property-drawer.open {
+  transform: translateX(0);
+  opacity: 1;
+  visibility: visible;
+  transition:
+    transform var(--drawer-transition),
+    opacity var(--drawer-transition),
+    visibility 0ms linear 0ms;
+}
+
+/* =============================================================================
+   Header
+   ============================================================================= */
+
+.drawer-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  border-bottom: 1px solid var(--drawer-border);
+  background: var(--drawer-surface);
+  flex-shrink: 0;
+}
+
+.drawer-title-group {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.drawer-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  background: var(--drawer-accent-dim);
+  border-radius: 4px;
+  color: var(--drawer-accent);
+}
+
+.drawer-title {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--drawer-text);
+  text-transform: uppercase;
+  letter-spacing: 0.75px;
+  font-family: 'SF Mono', 'Consolas', 'Monaco', monospace;
+}
+
+.drawer-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  color: var(--drawer-text-dim);
+  cursor: pointer;
+  transition: all 150ms ease;
+}
+
+.drawer-close:hover {
+  background: rgba(255, 255, 255, 0.05);
+  border-color: var(--drawer-border);
+  color: var(--drawer-text);
+}
+
+.drawer-close:active {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+/* =============================================================================
+   Content
+   ============================================================================= */
+
+.drawer-content {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+  padding: 16px;
+}
+
+.drawer-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100px;
+  color: var(--drawer-text-dim);
+  font-size: 13px;
+  font-style: italic;
+}
+
+/* =============================================================================
+   Property Content
+   ============================================================================= */
+
+.property-content {
+  animation: fadeSlideIn 200ms ease-out;
+}
+
+@keyframes fadeSlideIn {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Type Section */
+.property-type-section {
+  margin-bottom: 16px;
+}
+
+.type-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 14px;
+  background: var(--drawer-surface);
+  border: 1px solid var(--drawer-border);
+  border-radius: 6px;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.03),
+    0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.type-badge-icon {
+  font-family: 'SF Mono', 'Consolas', 'Monaco', monospace;
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--drawer-accent);
+  letter-spacing: -1px;
+}
+
+.type-badge-label {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--drawer-text);
+}
+
+/* Property List */
+.property-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.property-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 10px 12px;
+  margin: 0 -12px;
+  gap: 12px;
+  border-radius: 4px;
+  transition: background-color 100ms ease;
+}
+
+.property-row:hover {
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.property-row.dimmed {
+  opacity: 0.6;
+}
+
+.property-row.dimmed:hover {
+  opacity: 0.8;
+}
+
+.property-label {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--drawer-text-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  flex-shrink: 0;
+}
+
+.property-value {
+  font-size: 13px;
+  color: var(--drawer-text);
+  text-align: right;
+  word-break: break-word;
+  margin: 0;
+}
+
+.property-value.mono {
+  font-family: 'SF Mono', 'Consolas', 'Monaco', monospace;
+  font-size: 12px;
+  letter-spacing: -0.25px;
+}
+
+.property-value.accent {
+  color: var(--drawer-accent);
+  font-weight: 500;
+}
+
+/* =============================================================================
+   Decorative Circuit Lines
+   ============================================================================= */
+
+.drawer-circuit-lines {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 80px;
+  pointer-events: none;
+  overflow: hidden;
+  opacity: 0.4;
+}
+
+.circuit-line {
+  position: absolute;
+  background: var(--drawer-border);
+}
+
+.circuit-line--1 {
+  left: 16px;
+  bottom: 20px;
+  width: 40px;
+  height: 1px;
+}
+
+.circuit-line--1::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: -3px;
+  width: 1px;
+  height: 7px;
+  background: var(--drawer-border);
+}
+
+.circuit-line--1::after {
+  content: '';
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  width: 1px;
+  height: 25px;
+  background: var(--drawer-border);
+}
+
+.circuit-line--2 {
+  left: 70px;
+  bottom: 45px;
+  width: 30px;
+  height: 1px;
+}
+
+.circuit-line--2::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  bottom: -8px;
+  width: 1px;
+  height: 17px;
+  background: var(--drawer-border);
+}
+
+.circuit-line--3 {
+  right: 40px;
+  bottom: 30px;
+  width: 50px;
+  height: 1px;
+}
+
+.circuit-line--3::after {
+  content: '';
+  position: absolute;
+  right: 0;
+  top: -15px;
+  width: 1px;
+  height: 16px;
+  background: var(--drawer-border);
+}
+
+/* =============================================================================
+   Mobile Styles - Hide drawer on mobile (uses MobileLayout's tab system)
+   ============================================================================= */
+
+@media (max-width: 767px) {
+  .property-drawer,
+  .property-drawer-backdrop {
+    display: none;
+  }
+}
+
+/* =============================================================================
+   Reduced Motion
+   ============================================================================= */
+
+@media (prefers-reduced-motion: reduce) {
+  .property-drawer,
+  .property-drawer-backdrop {
+    transition: none;
+  }
+
+  .property-content {
+    animation: none;
+  }
+}

--- a/src/components/property-drawer/PropertyDrawer.tsx
+++ b/src/components/property-drawer/PropertyDrawer.tsx
@@ -1,0 +1,291 @@
+/**
+ * Property Drawer Component
+ *
+ * A slide-in panel that displays properties of the selected ladder element.
+ * Appears from the right edge when a node is selected.
+ * Can be dismissed via close button, clicking outside, or pressing Escape.
+ */
+
+import { useEffect, useCallback, memo } from 'react';
+import type { LadderNode, LadderNodeData } from '../../models/ladder-elements';
+
+import './PropertyDrawer.css';
+
+interface PropertyDrawerProps {
+  selectedNode: LadderNode | null;
+  onClose: () => void;
+}
+
+export const PropertyDrawer = memo(function PropertyDrawer({
+  selectedNode,
+  onClose,
+}: PropertyDrawerProps) {
+  const isOpen = selectedNode !== null;
+
+  // Handle Escape key to close
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'Escape' && isOpen) {
+        onClose();
+      }
+    },
+    [isOpen, onClose]
+  );
+
+  useEffect(() => {
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [handleKeyDown]);
+
+  // Handle backdrop click
+  const handleBackdropClick = useCallback(
+    (e: React.MouseEvent) => {
+      if (e.target === e.currentTarget) {
+        onClose();
+      }
+    },
+    [onClose]
+  );
+
+  return (
+    <>
+      {/* Backdrop - clickable to close */}
+      <div
+        className={`property-drawer-backdrop ${isOpen ? 'visible' : ''}`}
+        onClick={handleBackdropClick}
+        aria-hidden="true"
+      />
+
+      {/* Drawer panel */}
+      <aside
+        className={`property-drawer ${isOpen ? 'open' : ''}`}
+        role="complementary"
+        aria-label="Element Properties"
+        aria-hidden={!isOpen}
+      >
+        {/* Header */}
+        <header className="drawer-header">
+          <div className="drawer-title-group">
+            <div className="drawer-icon">
+              <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor">
+                <path d="M4 2.5a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1zm3 0a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm0 4a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm0 4a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm-3-4a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1zm0 4a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1z"/>
+              </svg>
+            </div>
+            <h2 className="drawer-title">Properties</h2>
+          </div>
+          <button
+            className="drawer-close"
+            onClick={onClose}
+            aria-label="Close properties panel"
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2">
+              <path d="M18 6L6 18M6 6l12 12" />
+            </svg>
+          </button>
+        </header>
+
+        {/* Content */}
+        <div className="drawer-content">
+          {selectedNode ? (
+            <PropertyContent node={selectedNode} />
+          ) : (
+            <div className="drawer-empty">
+              <span>No selection</span>
+            </div>
+          )}
+        </div>
+
+        {/* Decorative circuit lines */}
+        <div className="drawer-circuit-lines" aria-hidden="true">
+          <div className="circuit-line circuit-line--1" />
+          <div className="circuit-line circuit-line--2" />
+          <div className="circuit-line circuit-line--3" />
+        </div>
+      </aside>
+    </>
+  );
+});
+
+// =============================================================================
+// Property Content
+// =============================================================================
+
+interface PropertyContentProps {
+  node: LadderNode;
+}
+
+const PropertyContent = memo(function PropertyContent({ node }: PropertyContentProps) {
+  const typeLabel = getNodeTypeLabel(node.type);
+  const typeIcon = getNodeTypeIcon(node.type);
+
+  return (
+    <div className="property-content">
+      {/* Type badge */}
+      <div className="property-type-section">
+        <div className="type-badge">
+          <span className="type-badge-icon">{typeIcon}</span>
+          <span className="type-badge-label">{typeLabel}</span>
+        </div>
+      </div>
+
+      {/* Properties list */}
+      <div className="property-list">
+        <PropertyRow label="ID" value={node.id} mono dimmed />
+        {node.data && renderNodeSpecificProperties(node.data)}
+      </div>
+    </div>
+  );
+});
+
+// =============================================================================
+// Property Row
+// =============================================================================
+
+interface PropertyRowProps {
+  label: string;
+  value: string | number;
+  mono?: boolean;
+  dimmed?: boolean;
+  accent?: boolean;
+}
+
+function PropertyRow({ label, value, mono = false, dimmed = false, accent = false }: PropertyRowProps) {
+  return (
+    <div className={`property-row ${dimmed ? 'dimmed' : ''}`}>
+      <dt className="property-label">{label}</dt>
+      <dd className={`property-value ${mono ? 'mono' : ''} ${accent ? 'accent' : ''}`}>
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function getNodeTypeLabel(type: string | undefined): string {
+  switch (type) {
+    case 'contact':
+      return 'Contact';
+    case 'coil':
+      return 'Coil';
+    case 'timer':
+      return 'Timer';
+    case 'counter':
+      return 'Counter';
+    case 'comparator':
+      return 'Comparator';
+    case 'powerRail':
+      return 'Power Rail';
+    default:
+      return type || 'Unknown';
+  }
+}
+
+function getNodeTypeIcon(type: string | undefined): string {
+  switch (type) {
+    case 'contact':
+      return '┤├';
+    case 'coil':
+      return '( )';
+    case 'timer':
+      return '⏱';
+    case 'counter':
+      return '#';
+    case 'comparator':
+      return '≷';
+    case 'powerRail':
+      return '│';
+    default:
+      return '◇';
+  }
+}
+
+function renderNodeSpecificProperties(data: LadderNodeData) {
+  switch (data.elementType) {
+    case 'contact':
+      return (
+        <>
+          <PropertyRow label="Variable" value={data.variable || '—'} mono accent />
+          <PropertyRow label="Contact Type" value={formatContactType(data.contactType)} />
+        </>
+      );
+
+    case 'coil':
+      return (
+        <>
+          <PropertyRow label="Variable" value={data.variable || '—'} mono accent />
+          <PropertyRow label="Coil Type" value={formatCoilType(data.coilType)} />
+        </>
+      );
+
+    case 'timer':
+      return (
+        <>
+          <PropertyRow label="Instance" value={data.instanceName || '—'} mono accent />
+          <PropertyRow label="Timer Type" value={data.timerType || 'TON'} />
+          <PropertyRow label="Preset (PT)" value={data.presetTime || '—'} />
+        </>
+      );
+
+    case 'counter':
+      return (
+        <>
+          <PropertyRow label="Instance" value={data.instanceName || '—'} mono accent />
+          <PropertyRow label="Counter Type" value={data.counterType || 'CTU'} />
+          <PropertyRow label="Preset (PV)" value={data.presetValue ?? '—'} />
+        </>
+      );
+
+    case 'comparator':
+      return (
+        <>
+          <PropertyRow label="Left Operand" value={data.leftOperand || '—'} mono />
+          <PropertyRow label="Operator" value={data.operator || '—'} accent />
+          <PropertyRow label="Right Operand" value={data.rightOperand || '—'} mono />
+        </>
+      );
+
+    case 'powerRail':
+      return (
+        <PropertyRow
+          label="Rail Type"
+          value={data.railType === 'left' ? 'Left Rail (L+)' : 'Right Rail (L−)'}
+        />
+      );
+
+    default:
+      return null;
+  }
+}
+
+function formatContactType(type: string | undefined): string {
+  switch (type) {
+    case 'NO':
+      return 'Normally Open (NO)';
+    case 'NC':
+      return 'Normally Closed (NC)';
+    case 'P':
+      return 'Positive Edge (P)';
+    case 'N':
+      return 'Negative Edge (N)';
+    default:
+      return type || 'Normally Open (NO)';
+  }
+}
+
+function formatCoilType(type: string | undefined): string {
+  switch (type) {
+    case 'standard':
+      return 'Standard';
+    case 'negated':
+      return 'Negated';
+    case 'set':
+      return 'Set (Latch)';
+    case 'reset':
+      return 'Reset (Unlatch)';
+    default:
+      return type || 'Standard';
+  }
+}

--- a/src/components/property-drawer/index.ts
+++ b/src/components/property-drawer/index.ts
@@ -1,0 +1,1 @@
+export { PropertyDrawer } from './PropertyDrawer';

--- a/src/components/variable-watch/VariableWatch.tsx
+++ b/src/components/variable-watch/VariableWatch.tsx
@@ -3,7 +3,7 @@
  *
  * Displays and allows editing of simulation variables.
  * Shows boolean, integer, real, timer, and counter states.
- * Also includes Properties tab for selected node details.
+ * Properties tab is only shown when selectedNode is provided (mobile layout).
  */
 
 import { memo, useCallback, useState } from 'react';
@@ -24,6 +24,8 @@ export const VariableWatch = memo(function VariableWatch({
   onToggleCollapse,
   selectedNode = null,
 }: VariableWatchProps) {
+  // Only show properties tab when selectedNode prop is explicitly provided (mobile layout)
+  const showPropertiesTab = selectedNode !== undefined && selectedNode !== null;
   const [activeTab, setActiveTab] = useState<'booleans' | 'numbers' | 'timers' | 'counters' | 'properties'>('booleans');
 
   // Simulation state
@@ -98,15 +100,17 @@ export const VariableWatch = memo(function VariableWatch({
         >
           CTR
         </button>
-        <button
-          className={`watch-tab watch-tab--props ${activeTab === 'properties' ? 'active' : ''} ${selectedNode ? 'watch-tab--has-selection' : ''}`}
-          onClick={() => setActiveTab('properties')}
-          title="Selected Element Properties"
-        >
-          <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
-            <path d="M4 2.5a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1zm3 0a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm0 4a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm0 4a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm-3-4a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1zm0 4a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1z"/>
-          </svg>
-        </button>
+        {showPropertiesTab && (
+          <button
+            className={`watch-tab watch-tab--props ${activeTab === 'properties' ? 'active' : ''} ${selectedNode ? 'watch-tab--has-selection' : ''}`}
+            onClick={() => setActiveTab('properties')}
+            title="Selected Element Properties"
+          >
+            <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+              <path d="M4 2.5a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1zm3 0a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm0 4a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm0 4a.5.5 0 0 1 .5-.5h7a.5.5 0 0 1 0 1h-7a.5.5 0 0 1-.5-.5zm-3-4a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1zm0 4a.5.5 0 0 1 .5-.5h1a.5.5 0 0 1 .5.5v1a.5.5 0 0 1-.5.5h-1a.5.5 0 0 1-.5-.5v-1z"/>
+            </svg>
+          </button>
+        )}
       </div>
 
       <div className="watch-content">
@@ -138,7 +142,7 @@ export const VariableWatch = memo(function VariableWatch({
             onReset={resetCounter}
           />
         )}
-        {activeTab === 'properties' && (
+        {showPropertiesTab && activeTab === 'properties' && (
           <PropertiesContent selectedNode={selectedNode} />
         )}
       </div>


### PR DESCRIPTION
## Summary
- Adds a new `PropertyDrawer` component that slides in from the right edge when selecting a ladder diagram element
- Industrial/technical aesthetic with circuit-line decorations matching the app's theme
- Properly hideable via close button, clicking outside, or pressing Escape key
- Mobile continues to use the existing MobileLayout tab system (drawer hidden on mobile)
- Desktop VariableWatch no longer shows the properties tab (cleaner separation)

## Test plan
- [ ] Click on a contact/coil/timer/counter in the ladder diagram and verify the drawer slides in
- [ ] Verify properties display correctly for different element types
- [ ] Test closing via X button, clicking backdrop, and pressing Escape
- [ ] Test on mobile viewport - drawer should be hidden, properties still accessible via bottom tab bar
- [ ] Test reduced-motion preference (animations should be disabled)

🤖 Generated with [Claude Code](https://claude.com/claude-code)