### PR TITLE
Fix mobile variable list scrolling and preserve variables on stop

### DIFF
--- a/src/components/mobile/MobileLayout.css
+++ b/src/components/mobile/MobileLayout.css
@@ -732,8 +732,11 @@
 
 .mobile-variable-watch {
   flex: 1;
-  overflow: hidden;
+  overflow: auto;
   background: var(--mobile-bg-base);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
 
 /* ============================================================================

--- a/src/components/mobile/MobileLayout.tsx
+++ b/src/components/mobile/MobileLayout.tsx
@@ -80,7 +80,6 @@ export function MobileLayout() {
   const startSimulation = useSimulationStore((state) => state.start);
   const pauseSimulation = useSimulationStore((state) => state.pause);
   const stopSimulation = useSimulationStore((state) => state.stop);
-  const resetSimulation = useSimulationStore((state) => state.reset);
   const stepSimulation = useSimulationStore((state) => state.step);
   const updateTimer = useSimulationStore((state) => state.updateTimer);
   const timers = useSimulationStore((state) => state.timers);
@@ -174,8 +173,7 @@ export function MobileLayout() {
 
   const handleStop = useCallback(() => {
     stopSimulation();
-    resetSimulation();
-  }, [stopSimulation, resetSimulation]);
+  }, [stopSimulation]);
 
   // Auto-save when files change
   useEffect(() => {


### PR DESCRIPTION
- Enable scrolling in mobile variable watch by changing overflow from hidden to auto
- Add flex layout properties to ensure proper height calculation
- Remove resetSimulation() call from handleStop to preserve variables when stopping
- Variables are now retained when pressing stop button on mobile