### PR TITLE
Fix Try in Editor button by initializing project store on startup

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import { initializeMobileStore } from './store/mobile-store'
 import { initializeOnboarding } from './store/onboarding-store'
 import { initializeEditorStore } from './store/editor-store'
 import { initializeUIStore } from './store/ui-store'
+import { initializeProjectStore } from './store/project-store'
 
 // Initialize mobile store to detect device type and set up listeners
 initializeMobileStore();
@@ -17,6 +18,9 @@ initializeEditorStore();
 
 // Initialize UI store (panel visibility, etc.)
 initializeUIStore();
+
+// Initialize project store from localStorage (once on app start)
+initializeProjectStore();
 
 // Initialize onboarding for first-time visitors
 initializeOnboarding();


### PR DESCRIPTION
The "Try in Editor" button was broken because initializeProjectStore()
was not being called on app startup in main.tsx. This meant that when
navigating from docs to the editor, the project store didn't load the
saved state from localStorage, causing the newly created program to be lost.

Added the missing initializeProjectStore() import and call to ensure
the project store loads saved state when the app starts.