### PR TITLE
feat(variables): AB-style variable table with manifest import

### DIFF
--- a/e2e/mira-audit.spec.ts
+++ b/e2e/mira-audit.spec.ts
@@ -1,0 +1,195 @@
+import { test, expect, Page } from '@playwright/test';
+
+const CONVEYOR_ST = `PROGRAM ConveyorPhase1
+VAR_INPUT
+    DI_02 : BOOL;
+    DI_00 : BOOL;
+    DI_01 : BOOL;
+END_VAR
+VAR_OUTPUT
+    DO_02 : BOOL;
+    dir_fwd : BOOL;
+    dir_rev : BOOL;
+END_VAR
+VAR
+    e_stop_active : BOOL;
+    vfd_cmd : INT;
+    vfd_freq : INT;
+    poll_timer : TON;
+END_VAR
+e_stop_active := NOT DI_02;
+DO_02 := NOT e_stop_active;
+dir_fwd := DI_00 AND NOT DI_01;
+dir_rev := NOT DI_00 AND DI_01;
+IF dir_fwd AND NOT e_stop_active THEN
+    vfd_cmd := 18;
+ELSIF dir_rev AND NOT e_stop_active THEN
+    vfd_cmd := 20;
+ELSE
+    vfd_cmd := 1;
+END_IF;
+vfd_freq := 300;
+poll_timer(IN := NOT poll_timer.Q, PT := T#500ms);
+END_PROGRAM`;
+
+async function clearAndTypeProgram(page: Page, stCode: string) {
+  // Find the CodeMirror editor
+  const editor = page.locator('.cm-editor').first();
+  await editor.click();
+  // Select all and replace
+  await page.keyboard.press('Control+a');
+  await page.keyboard.press('Delete');
+  await page.waitForTimeout(300);
+  await page.keyboard.type(stCode);
+  await page.waitForTimeout(1000);
+}
+
+test.describe('MIRA Conveyor Audit', () => {
+
+  test('01 - app loads and ST editor is visible', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForTimeout(2000);
+    await page.screenshot({ path: 'e2e/screenshots/01-initial-load.png', fullPage: true });
+
+    const editor = page.locator('.cm-editor');
+    await expect(editor.first()).toBeVisible();
+  });
+
+  test('02 - ladder canvas exists in DOM', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForTimeout(2000);
+
+    // React Flow renders a .react-flow container
+    const canvas = page.locator('.react-flow');
+    const exists = await canvas.count();
+    console.log(`React Flow containers found: ${exists}`);
+
+    await page.screenshot({ path: 'e2e/screenshots/02-canvas-check.png', fullPage: true });
+    expect(exists).toBeGreaterThan(0);
+  });
+
+  test('03 - ladder renders nodes after pasting conveyor ST', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForTimeout(2000);
+
+    await clearAndTypeProgram(page, CONVEYOR_ST);
+    await page.waitForTimeout(2000);
+
+    await page.screenshot({ path: 'e2e/screenshots/03-after-st-input.png', fullPage: true });
+
+    // Check React Flow nodes exist
+    const nodes = page.locator('.react-flow__node');
+    const nodeCount = await nodes.count();
+    console.log(`Ladder nodes rendered: ${nodeCount}`);
+
+    // Check for any ladder-specific elements
+    const edges = page.locator('.react-flow__edge');
+    const edgeCount = await edges.count();
+    console.log(`Ladder edges rendered: ${edgeCount}`);
+
+    expect(nodeCount).toBeGreaterThan(0);
+  });
+
+  test('04 - default program renders something', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForTimeout(3000);
+
+    const nodes = page.locator('.react-flow__node');
+    const nodeCount = await nodes.count();
+    console.log(`Default program nodes: ${nodeCount}`);
+
+    await page.screenshot({ path: 'e2e/screenshots/04-default-program.png', fullPage: true });
+
+    // Log what the ST editor actually contains by default
+    const editorContent = await page.locator('.cm-content').first().textContent();
+    console.log('Default ST content length:', editorContent?.length);
+    console.log('Default ST preview:', editorContent?.slice(0, 200));
+  });
+
+  test('05 - react flow viewport is not empty (has transform)', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForTimeout(3000);
+
+    const viewport = page.locator('.react-flow__viewport');
+    const transform = await viewport.getAttribute('style');
+    console.log('Viewport transform:', transform);
+
+    // If the viewport has a degenerate transform (all zeros or none), ladder is blank
+    await page.screenshot({ path: 'e2e/screenshots/05-viewport.png', fullPage: true });
+  });
+
+  test('06 - check console errors on ST input', async ({ page }) => {
+    const errors: string[] = [];
+    const warnings: string[] = [];
+
+    page.on('console', msg => {
+      if (msg.type() === 'error') errors.push(msg.text());
+      if (msg.type() === 'warning') warnings.push(msg.text());
+    });
+    page.on('pageerror', err => errors.push(err.message));
+
+    await page.goto('/');
+    await page.waitForTimeout(1000);
+    await clearAndTypeProgram(page, CONVEYOR_ST);
+    await page.waitForTimeout(2000);
+
+    console.log('Console errors after ST input:', errors);
+    console.log('Console warnings:', warnings);
+
+    await page.screenshot({ path: 'e2e/screenshots/06-errors-after-input.png', fullPage: true });
+  });
+
+  test('07 - button nesting HTML bug', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForTimeout(2000);
+
+    // The debug test found <button> inside <button> in FileTabs
+    const nestedButtons = page.locator('button button');
+    const count = await nestedButtons.count();
+    console.log(`Nested button violations: ${count}`);
+
+    // This should be 0 — it's invalid HTML
+    expect(count).toBe(0);
+  });
+
+  test('08 - react flow nodeTypes recreation warning', async ({ page }) => {
+    const warnings: string[] = [];
+    page.on('console', msg => {
+      if (msg.text().includes('nodeTypes') || msg.text().includes('edgeTypes')) {
+        warnings.push(msg.text());
+      }
+    });
+
+    await page.goto('/');
+    await page.waitForTimeout(2000);
+
+    console.log('nodeTypes/edgeTypes recreation warnings:', warnings.length);
+    console.log(warnings);
+    // Should be 0 after fix
+    expect(warnings.length).toBe(0);
+  });
+
+  test('09 - simulate: toggle DI_02 (e-stop) and check DO_02 output', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForTimeout(1000);
+    await clearAndTypeProgram(page, CONVEYOR_ST);
+    await page.waitForTimeout(2000);
+
+    // Look for variable watch panel
+    const watchPanel = page.locator('[class*="variable-watch"], [class*="watch-panel"], [data-testid*="watch"]');
+    const watchExists = await watchPanel.count();
+    console.log(`Variable watch panel found: ${watchExists}`);
+
+    await page.screenshot({ path: 'e2e/screenshots/09-simulation.png', fullPage: true });
+  });
+
+  test('10 - full page screenshot at rest', async ({ page }) => {
+    await page.goto('/');
+    await page.waitForTimeout(3000);
+    await clearAndTypeProgram(page, CONVEYOR_ST);
+    await page.waitForTimeout(3000);
+    await page.screenshot({ path: 'e2e/screenshots/10-full-state.png', fullPage: true });
+    console.log('Screenshot saved to e2e/screenshots/10-full-state.png');
+  });
+
+});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ladder-logic-editor",
   "private": true,
-  "version": "0.0.0",
+  "version": "0.1.0",
   "type": "module",
   "homepage": "https://lle.dilger.dev/",
   "scripts": {

--- a/research/ralph-build.md
+++ b/research/ralph-build.md
@@ -1,0 +1,48 @@
+# Ralph Loop: Phase 2 — PDF Build
+
+## Mission
+Read research/variable-manifest.json and build the complete commissioning PDF via the ladder-logic-editor. Loop until every section is complete with no gaps.
+
+## Prerequisites
+- Phase 1 manifest exists at research/variable-manifest.json in MIRA repo
+- ladder-logic-editor running at localhost:5173
+
+## Steps
+
+### 1. Load the manifest
+gh api repos/Mikecranesync/MIRA/contents/research/variable-manifest.json -q .content | base64 -d
+
+### 2. Review completeness
+For each variable in the manifest, verify:
+- alias is present (not null/empty)
+- direction is set for all wired I/O
+- terminalLabel is set for all physical I/O
+- modbusAddress is set for all Modbus-exported variables
+
+### 3. Build the PDF
+The PrintView component in the ladder-logic-editor will auto-render all PDF sections when the manifest is loaded. Trigger the print flow:
+- Open localhost:5173 in browser (or instruct user to)
+- The editor reads the manifest from /research/variable-manifest.json
+- PDF sections render: Cover, Variable Table, Wiring Diagram, I/O Checklist, Modbus Map, CCW Steps, Ignition Setup, Gaps
+
+### 4. Review each section
+For each section, verify:
+- Cover: program name, date, target PLC model present
+- Variable Table: all variables listed with alias, direction, address, Modbus, terminal, device
+- Wiring Diagram: all DI/DO appear as wired terminals with alias labels
+- I/O Checklist: one row per physical I/O point
+- Modbus Register Map: all modbusAddress entries present and correct
+- CCW Steps: step count matches rung count, all variable bindings named
+- Ignition Setup: tag paths match manifest variable names
+- Gaps: accurately lists all unresolved items
+
+### 5. Fix and iterate
+If any section is incomplete:
+- For missing aliases: add them to the manifest and re-commit
+- For missing terminal labels: research wiring notes and add
+- Re-run review until all sections pass
+
+## Done When
+- PDF has zero unaliased variables
+- Wiring diagram shows all physical I/O
+- Gaps section is either empty or lists only items that require physical inspection

--- a/research/ralph-research.md
+++ b/research/ralph-research.md
@@ -1,0 +1,59 @@
+# Ralph Loop: Phase 1 — Variable Research
+
+## Mission
+Read every available source for the Micro 820 conveyor system and produce a complete variable manifest at research/variable-manifest.json in the MIRA repo. Loop until no new fields can be filled from available sources.
+
+## Sources to Read (in order)
+1. gh api repos/Mikecranesync/MIRA/contents/plc/specs/Prog2_ladder.md -q .content | base64 -d
+2. gh api repos/Mikecranesync/MIRA/contents/plc/specs/phase1_ladder.md -q .content | base64 -d
+3. gh api repos/Mikecranesync/MIRA/contents/plc/specs/phase1_conveyor.iecst -q .content | base64 -d
+4. gh api repos/Mikecranesync/MIRA/contents/controller/Controller/LogicalValues.csv -q .content | base64 -d
+5. gh api repos/Mikecranesync/MIRA/contents/drive_test/step1_io_check/MbSrvConf_import.csv -q .content | base64 -d
+6. Check if Ignition MCP is available: curl -s http://100.72.2.99:8765/health
+
+## For Each Variable Found, Extract
+- name: exact PLC variable name (e.g. _IO_EM_DI_02, vfd_cmd_word)
+- dataType: BOOL / INT / UINT / REAL / TON / etc.
+- scope: VAR_INPUT / VAR_OUTPUT / VAR / VAR_TEMP
+- alias: human-readable label from Prog2_ladder.md shorthands or comments
+  - I/O shorthand map: I-00=_IO_EM_DI_00, I-01=_IO_EM_DI_01, etc.
+  - O-00=_IO_EM_DO_00, O-01=_IO_EM_DO_01, etc.
+  - Look for inline comments after each variable in ST source
+- address: hardware address from CCW (%IX0.0 for DI_00, %QX0.0 for DO_00, etc.)
+- modbusAddress: from MbSrvConf_import.csv (COIL:N or HR:N)
+- retain: TRUE if variable must survive power cycle (look for RETAIN keyword or notes)
+- terminalLabel: physical terminal from wiring notes (TB1-N, VFD-FWD, etc.)
+- sourceDevice: GS10 VFD / E-stop / Ignition / Internal / Micro 820
+- direction: IN (VAR_INPUT) / OUT (VAR_OUTPUT)
+
+## Alias Assignment Rules
+- _IO_EM_DI_00..19 = digital inputs — label from context (e.g. "Run PB", "E-stop NC", "Fault Reset")
+- _IO_EM_DO_00..07 = digital outputs — label from context (e.g. "Run Relay", "Fault Lamp")
+- _IO_EM_AI_00..01 = analog inputs
+- vfd_* = VFD control/feedback variables — sourceDevice: GS10 VFD
+- e_stop_* = sourceDevice: E-stop
+- Variables written by Ignition via Modbus = sourceDevice: Ignition
+
+## Output Format
+Commit research/variable-manifest.json to MIRA repo (main branch) with this structure:
+{
+  "generatedAt": "<ISO timestamp>",
+  "sourceFiles": ["plc/specs/Prog2_ladder.md", ...],
+  "variables": [ { name, dataType, scope, alias, address, modbusAddress, retain, terminalLabel, sourceDevice, direction } ],
+  "wiringNotes": [ "<freeform wiring facts discovered>" ],
+  "gaps": [ { "variableName": "", "missingFields": [], "note": "" } ]
+}
+
+## Loop Behavior
+1. Read all sources
+2. Build the manifest with all fields you can determine
+3. Mark any variable where alias, terminalLabel, or sourceDevice is unknown as a gap
+4. Report the gap count and list
+5. If gaps remain that could be resolved with Ignition MCP data, try fetching tags
+6. Stop when no further data can be extracted from available sources
+
+## Done When
+- All _IO_EM_* variables have alias and direction
+- All vfd_* variables have alias and sourceDevice
+- All Modbus-exported variables have modbusAddress
+- gaps list documents exactly what is unknown and why

--- a/src/components/file-tabs/FileTabs.tsx
+++ b/src/components/file-tabs/FileTabs.tsx
@@ -39,10 +39,13 @@ export function FileTabs() {
     <div className="file-tabs">
       <div className="file-tabs-list">
         {filesArray.map((file: OpenFile) => (
-          <button
+          <div
             key={file.id}
+            role="tab"
+            tabIndex={0}
             className={`file-tab ${file.id === activeFileId ? 'active' : ''} ${file.isDirty ? 'dirty' : ''}`}
             onClick={() => setActiveFile(file.id)}
+            onKeyDown={(e) => e.key === 'Enter' || e.key === ' ' ? setActiveFile(file.id) : undefined}
             title={file.name}
           >
             <span className="file-tab-name">
@@ -56,7 +59,7 @@ export function FileTabs() {
             >
               ×
             </button>
-          </button>
+          </div>
         ))}
       </div>
       <button

--- a/src/components/ladder-editor/LadderCanvas.tsx
+++ b/src/components/ladder-editor/LadderCanvas.tsx
@@ -13,9 +13,20 @@ import ReactFlow, {
   addEdge,
   useNodesState,
   useEdgesState,
+  useReactFlow,
   BackgroundVariant,
   type OnSelectionChangeParams,
 } from 'reactflow';
+
+function FitViewOnChange({ nodeCount }: { nodeCount: number }) {
+  const { fitView } = useReactFlow();
+  useEffect(() => {
+    if (nodeCount > 0) {
+      setTimeout(() => fitView({ duration: 300, padding: 0.12 }), 50);
+    }
+  }, [nodeCount, fitView]);
+  return null;
+}
 import type { Node, Connection } from 'reactflow';
 import 'reactflow/dist/style.css';
 
@@ -186,6 +197,7 @@ export function LadderCanvas({
             size={1}
             color={themeColors.grid}
           />
+          <FitViewOnChange nodeCount={nodes.length} />
           {!isMobile && <Controls />}
           {!isMobile && (
             <MiniMap

--- a/src/components/ladder-editor/LadderCanvas.tsx
+++ b/src/components/ladder-editor/LadderCanvas.tsx
@@ -32,6 +32,7 @@ import 'reactflow/dist/style.css';
 
 import { ladderNodeTypes } from './nodes';
 import type { LadderNode, LadderEdge } from '../../models/ladder-elements';
+import { useSimulationStore } from '../../store';
 import { useIsMobile } from '../../hooks';
 
 import './LadderCanvas.css';
@@ -83,6 +84,23 @@ export function LadderCanvas({
   useEffect(() => {
     setEdges(initialEdges);
   }, [initialEdges, setEdges]);
+
+  // Color edges based on power flow state
+  const poweredEdgeIds = useSimulationStore((state) => state.poweredEdgeIds);
+  useEffect(() => {
+    const style = getComputedStyle(document.documentElement);
+    const successColor = style.getPropertyValue('--color-success').trim() || '#4ec9b0';
+    setEdges((prev) =>
+      prev.map((e) => ({
+        ...e,
+        style: {
+          ...e.style,
+          stroke: poweredEdgeIds.has(e.id) ? successColor : themeColors.edge,
+          strokeWidth: poweredEdgeIds.has(e.id) ? 3 : 2,
+        },
+      }))
+    );
+  }, [poweredEdgeIds, setEdges, themeColors.edge]);
 
   // Handle new connections
   const onConnect = useCallback(

--- a/src/components/ladder-editor/nodes/CoilNode.tsx
+++ b/src/components/ladder-editor/nodes/CoilNode.tsx
@@ -9,6 +9,7 @@ import { memo } from 'react';
 import { Handle, Position } from 'reactflow';
 import type { NodeProps } from 'reactflow';
 import type { CoilNodeData } from '../../../models/ladder-elements';
+import { useProjectStore } from '../../../store';
 
 import './LadderNodes.css';
 
@@ -17,6 +18,11 @@ export const CoilNode = memo(function CoilNode({
   selected,
 }: NodeProps<CoilNodeData>) {
   const { variable, coilType } = data;
+
+  const alias = useProjectStore((state) => {
+    if (!variable) return undefined;
+    return state.manifestMetadata[variable]?.alias;
+  });
 
   // Determine symbol based on coil type
   const getSymbol = () => {
@@ -55,8 +61,11 @@ export const CoilNode = memo(function CoilNode({
         <div className="coil-right">)</div>
       </div>
 
-      {/* Variable name */}
-      <div className="node-label">{variable || '???'}</div>
+      {/* Variable name and alias */}
+      <div className="node-label">
+        <span className="node-var-name">{variable || '???'}</span>
+        {alias && <span className="node-alias" title={alias}>{alias}</span>}
+      </div>
 
       {/* Output handle (right side - to power rail) */}
       <Handle

--- a/src/components/ladder-editor/nodes/CoilNode.tsx
+++ b/src/components/ladder-editor/nodes/CoilNode.tsx
@@ -9,7 +9,7 @@ import { memo } from 'react';
 import { Handle, Position } from 'reactflow';
 import type { NodeProps } from 'reactflow';
 import type { CoilNodeData } from '../../../models/ladder-elements';
-import { useProjectStore } from '../../../store';
+import { useProjectStore, useSimulationStore } from '../../../store';
 
 import './LadderNodes.css';
 
@@ -23,6 +23,8 @@ export const CoilNode = memo(function CoilNode({
     if (!variable) return undefined;
     return state.manifestMetadata[variable]?.alias;
   });
+
+  const isPowered = useSimulationStore((state) => state.poweredNodeIds.has(data.id));
 
   // Determine symbol based on coil type
   const getSymbol = () => {
@@ -42,7 +44,7 @@ export const CoilNode = memo(function CoilNode({
 
   return (
     <div
-      className={`ladder-node coil-node ${coilType} ${selected ? 'selected' : ''}`}
+      className={`ladder-node coil-node ${coilType} ${selected ? 'selected' : ''} ${isPowered ? 'powered' : ''}`}
     >
       {/* Input handle (left side - receives power) */}
       <Handle

--- a/src/components/ladder-editor/nodes/ComparatorNode.tsx
+++ b/src/components/ladder-editor/nodes/ComparatorNode.tsx
@@ -9,6 +9,7 @@ import { memo } from 'react';
 import { Handle, Position } from 'reactflow';
 import type { NodeProps } from 'reactflow';
 import type { ComparatorNodeData } from '../../../models/ladder-elements';
+import { useSimulationStore } from '../../../store';
 
 import './LadderNodes.css';
 
@@ -17,6 +18,7 @@ export const ComparatorNode = memo(function ComparatorNode({
   selected,
 }: NodeProps<ComparatorNodeData>) {
   const { operator, leftOperand, rightOperand } = data;
+  const isPowered = useSimulationStore((state) => state.poweredNodeIds.has(data.id));
 
   // Get display symbol for operator
   const getOperatorSymbol = () => {
@@ -40,7 +42,7 @@ export const ComparatorNode = memo(function ComparatorNode({
 
   return (
     <div
-      className={`ladder-node comparator-node ${selected ? 'selected' : ''}`}
+      className={`ladder-node comparator-node ${selected ? 'selected' : ''} ${isPowered ? 'powered' : ''}`}
     >
       {/* Input handle (left side - receives power) */}
       <Handle

--- a/src/components/ladder-editor/nodes/ContactNode.tsx
+++ b/src/components/ladder-editor/nodes/ContactNode.tsx
@@ -9,7 +9,7 @@ import { memo } from 'react';
 import { Handle, Position } from 'reactflow';
 import type { NodeProps } from 'reactflow';
 import type { ContactNodeData } from '../../../models/ladder-elements';
-import { useProjectStore } from '../../../store';
+import { useProjectStore, useSimulationStore } from '../../../store';
 
 import './LadderNodes.css';
 
@@ -23,6 +23,8 @@ export const ContactNode = memo(function ContactNode({
     if (!variable) return undefined;
     return state.manifestMetadata[variable]?.alias;
   });
+
+  const isPowered = useSimulationStore((state) => state.poweredNodeIds.has(data.id));
 
   // Determine symbol based on contact type
   const getSymbol = () => {
@@ -42,7 +44,7 @@ export const ContactNode = memo(function ContactNode({
     <div
       className={`ladder-node contact-node ${contactType.toLowerCase()} ${
         selected ? 'selected' : ''
-      }`}
+      } ${isPowered ? 'powered' : ''}`}
     >
       {/* Input handle (left side - receives power) */}
       <Handle

--- a/src/components/ladder-editor/nodes/ContactNode.tsx
+++ b/src/components/ladder-editor/nodes/ContactNode.tsx
@@ -9,6 +9,7 @@ import { memo } from 'react';
 import { Handle, Position } from 'reactflow';
 import type { NodeProps } from 'reactflow';
 import type { ContactNodeData } from '../../../models/ladder-elements';
+import { useProjectStore } from '../../../store';
 
 import './LadderNodes.css';
 
@@ -17,6 +18,11 @@ export const ContactNode = memo(function ContactNode({
   selected,
 }: NodeProps<ContactNodeData>) {
   const { variable, contactType } = data;
+
+  const alias = useProjectStore((state) => {
+    if (!variable) return undefined;
+    return state.manifestMetadata[variable]?.alias;
+  });
 
   // Determine symbol based on contact type
   const getSymbol = () => {
@@ -55,8 +61,11 @@ export const ContactNode = memo(function ContactNode({
         <div className="contact-rail right" />
       </div>
 
-      {/* Variable name */}
-      <div className="node-label">{variable || '???'}</div>
+      {/* Variable name and alias */}
+      <div className="node-label">
+        <span className="node-var-name">{variable || '???'}</span>
+        {alias && <span className="node-alias" title={alias}>{alias}</span>}
+      </div>
 
       {/* Output handle (right side - passes power if condition met) */}
       <Handle

--- a/src/components/ladder-editor/nodes/CounterNode.tsx
+++ b/src/components/ladder-editor/nodes/CounterNode.tsx
@@ -11,6 +11,7 @@ import { memo } from 'react';
 import { Handle, Position } from 'reactflow';
 import type { NodeProps } from 'reactflow';
 import type { CounterNodeData } from '../../../models/ladder-elements';
+import { useSimulationStore } from '../../../store';
 
 import './LadderNodes.css';
 
@@ -19,6 +20,7 @@ export const CounterNode = memo(function CounterNode({
   selected,
 }: NodeProps<CounterNodeData>) {
   const { instanceName, counterType, presetValue } = data;
+  const isPowered = useSimulationStore((state) => state.poweredNodeIds.has(data.id));
 
   // CTUD has both count up and count down inputs
   const isCTUD = counterType === 'CTUD';
@@ -28,7 +30,7 @@ export const CounterNode = memo(function CounterNode({
     <div
       className={`ladder-node counter-node ${counterType.toLowerCase()} ${
         selected ? 'selected' : ''
-      }`}
+      } ${isPowered ? 'powered' : ''}`}
     >
       {/* Input handles (left side) */}
       {/* Main power input - use 'power-in' for compatibility with layout */}

--- a/src/components/ladder-editor/nodes/LadderNodes.css
+++ b/src/components/ladder-editor/nodes/LadderNodes.css
@@ -26,12 +26,29 @@
 
 .ladder-node .node-label {
   margin-top: 4px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 80px;
+}
+
+.node-var-name {
   font-size: 10px;
   color: var(--color-info);
   max-width: 80px;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+.node-alias {
+  font-size: 8px;
+  color: var(--color-muted-foreground);
+  max-width: 80px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-style: italic;
 }
 
 /* Handles */

--- a/src/components/ladder-editor/nodes/PowerRailNode.tsx
+++ b/src/components/ladder-editor/nodes/PowerRailNode.tsx
@@ -10,6 +10,7 @@ import { memo } from 'react';
 import { Handle, Position } from 'reactflow';
 import type { NodeProps } from 'reactflow';
 import type { PowerRailNodeData } from '../../../models/ladder-elements';
+import { useSimulationStore } from '../../../store';
 
 import './LadderNodes.css';
 
@@ -19,12 +20,13 @@ export const PowerRailNode = memo(function PowerRailNode({
 }: NodeProps<PowerRailNodeData>) {
   const { railType } = data;
   const isLeft = railType === 'left';
+  const isPowered = useSimulationStore((state) => state.poweredNodeIds.has(data.id));
 
   return (
     <div
       className={`ladder-node power-rail-node ${railType} ${
         selected ? 'selected' : ''
-      }`}
+      } ${isPowered ? 'powered' : ''}`}
     >
       {/* Rail line */}
       <div className="rail-line" />

--- a/src/components/ladder-editor/nodes/TimerNode.tsx
+++ b/src/components/ladder-editor/nodes/TimerNode.tsx
@@ -32,12 +32,13 @@ export const TimerNode = memo(function TimerNode({
 
   // Get timer runtime state from simulation store
   const timerState = useSimulationStore((state) => state.getTimer(instanceName));
+  const isPowered = useSimulationStore((state) => state.poweredNodeIds.has(data.id));
 
   return (
     <div
       className={`ladder-node timer-node ${timerType.toLowerCase()} ${
         selected ? 'selected' : ''
-      }`}
+      } ${isPowered ? 'powered' : ''}`}
     >
       {/* Input handles (left side) */}
       {/* Main power input - use 'power-in' for compatibility with layout */}

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -28,10 +28,13 @@ import {
   runScanCycle,
   initializeVariables,
   createRuntimeState,
+  evaluatePowerFlow,
   type RuntimeState,
   type SimulationStoreInterface,
 } from '../../interpreter';
 import { transformSTToLadder, type TransformResult } from '../../transformer';
+import type { LadderIR } from '../../transformer/ladder-ir';
+import type { DiagramLayout } from '../../transformer/layout';
 import type { STAST } from '../../transformer/ast';
 import type { LadderNode, LadderEdge } from '../../models/ladder-elements';
 
@@ -101,6 +104,8 @@ export function MainLayout() {
   // Interpreter state refs
   const currentASTRef = useRef<STAST | null>(null);
   const runtimeStateRef = useRef<RuntimeState | null>(null);
+  const currentIRRef = useRef<LadderIR | null>(null);
+  const currentLayoutRef = useRef<DiagramLayout | null>(null);
 
   // Simulation loop
   useEffect(() => {
@@ -133,6 +138,14 @@ export function MainLayout() {
           // Get fresh store reference for each cycle
           const store = useSimulationStore.getState() as SimulationStoreInterface;
           runScanCycle(ast, store, runtimeState);
+
+          // Evaluate power flow after scan cycle
+          const ir = currentIRRef.current;
+          const layout = currentLayoutRef.current;
+          if (ir && layout) {
+            const { poweredNodeIds, poweredEdgeIds } = evaluatePowerFlow(ir, store, runtimeState, layout);
+            useSimulationStore.getState().setPowerFlow(poweredNodeIds, poweredEdgeIds);
+          }
         } else {
           // Fallback: just update timers manually if no AST
           Object.keys(timers).forEach((timerName) => {
@@ -178,6 +191,7 @@ export function MainLayout() {
   const handleStop = useCallback(() => {
     stopSimulation();
     resetSimulation();
+    useSimulationStore.getState().setPowerFlow(new Set(), new Set());
   }, [stopSimulation, resetSimulation]);
 
   // Auto-save when files change
@@ -235,6 +249,9 @@ export function MainLayout() {
           initializeVariables(newAST, store);
           runtimeStateRef.current = createRuntimeState(newAST);
         }
+        // Store IR and layout for power flow evaluator
+        if (result.intermediates?.ir) currentIRRef.current = result.intermediates.ir;
+        if (result.intermediates?.layout) currentLayoutRef.current = result.intermediates.layout;
       } else {
         setSyncStatus('error');
         setErrorCount(result.errors.length);

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -34,6 +34,7 @@ import { transformSTToLadder, type TransformResult } from '../../transformer';
 import type { STAST } from '../../transformer/ast';
 import type { LadderNode, LadderEdge } from '../../models/ladder-elements';
 
+import { PrintView } from '../print-view/PrintView';
 import './MainLayout.css';
 
 export function MainLayout() {
@@ -397,6 +398,9 @@ export function MainLayout() {
           <HelpMenu />
         </div>
       </div>
+
+      {/* PDF Export print view — hidden on screen, shown on print */}
+      <PrintView />
     </div>
   );
 }

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -24,6 +24,7 @@ import {
   scheduleEditorAutoSave,
 } from '../../store';
 import { downloadSTFile } from '../../services/file-service';
+import { useLiveBridge } from '../../hooks/useLiveBridge';
 import {
   runScanCycle,
   initializeVariables,
@@ -76,6 +77,9 @@ export function MainLayout() {
   const stepSimulation = useSimulationStore((state) => state.step);
   const updateTimer = useSimulationStore((state) => state.updateTimer);
   const timers = useSimulationStore((state) => state.timers);
+
+  // Live bridge
+  const { liveStatus, liveError, toggleLive, stopLive } = useLiveBridge();
 
   // Manifest import
   const loadManifest = useProjectStore((state) => state.loadManifest);
@@ -192,7 +196,8 @@ export function MainLayout() {
     stopSimulation();
     resetSimulation();
     useSimulationStore.getState().setPowerFlow(new Set(), new Set());
-  }, [stopSimulation, resetSimulation]);
+    stopLive();
+  }, [stopSimulation, resetSimulation, stopLive]);
 
   // Auto-save when files change
   useEffect(() => {
@@ -372,6 +377,24 @@ export function MainLayout() {
           >
             <span className="toolbar-icon">⏹️</span>
             <span className="toolbar-label">Stop</span>
+          </button>
+        </div>
+
+        <div className="toolbar-separator" />
+
+        {/* Live PLC bridge button */}
+        <div className="toolbar-group">
+          <button
+            className={`toolbar-btn ${liveStatus === 'live' ? 'active' : ''} ${liveStatus === 'error' ? 'error' : ''}`}
+            title={liveStatus === 'error' ? `Live error: ${liveError}` : liveStatus === 'live' ? 'Live — click to disconnect' : liveStatus === 'connecting' ? 'Connecting to PLC…' : 'Connect to live PLC (requires manifest with Modbus addresses)'}
+            onClick={toggleLive}
+          >
+            <span className="toolbar-icon">
+              {liveStatus === 'live' ? '🔴' : liveStatus === 'connecting' ? '🟡' : liveStatus === 'error' ? '⚠️' : '📡'}
+            </span>
+            <span className="toolbar-label">
+              {liveStatus === 'live' ? 'Live ●' : liveStatus === 'connecting' ? 'Connecting…' : liveStatus === 'error' ? 'Error' : 'Live'}
+            </span>
           </button>
         </div>
 

--- a/src/components/layout/MainLayout.tsx
+++ b/src/components/layout/MainLayout.tsx
@@ -18,6 +18,7 @@ import { TutorialLightbulb } from '../onboarding';
 import { HelpMenu } from '../help-menu';
 import {
   useEditorStore,
+  useProjectStore,
   useSimulationStore,
   useUIStore,
   scheduleEditorAutoSave,
@@ -72,6 +73,26 @@ export function MainLayout() {
   const stepSimulation = useSimulationStore((state) => state.step);
   const updateTimer = useSimulationStore((state) => state.updateTimer);
   const timers = useSimulationStore((state) => state.timers);
+
+  // Manifest import
+  const loadManifest = useProjectStore((state) => state.loadManifest);
+  const manifestInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleManifestFile = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      try {
+        const parsed = JSON.parse(ev.target?.result as string);
+        loadManifest(parsed);
+      } catch {
+        console.warn('Failed to parse manifest JSON');
+      }
+    };
+    reader.readAsText(file);
+    e.target.value = '';
+  }, [loadManifest]);
 
   // Ref to track animation frame
   const animationFrameRef = useRef<number | null>(null);
@@ -276,6 +297,26 @@ export function MainLayout() {
           >
             <span className="toolbar-icon">💾</span>
             <span className="toolbar-label">Save{activeFile?.isDirty ? '*' : ''}</span>
+          </button>
+        </div>
+
+        <div className="toolbar-separator" />
+
+        <div className="toolbar-group">
+          <input
+            ref={manifestInputRef}
+            type="file"
+            accept=".json"
+            style={{ display: 'none' }}
+            onChange={handleManifestFile}
+          />
+          <button
+            className="toolbar-btn"
+            title="Load variable manifest JSON to add aliases and Modbus addresses"
+            onClick={() => manifestInputRef.current?.click()}
+          >
+            <span className="toolbar-icon">📋</span>
+            <span className="toolbar-label">Manifest</span>
           </button>
         </div>
 

--- a/src/components/open-menu/OpenMenu.tsx
+++ b/src/components/open-menu/OpenMenu.tsx
@@ -53,6 +53,11 @@ export function OpenMenu() {
     setIsOpen(false);
   };
 
+  const handleExportPdf = () => {
+    window.print();
+    setIsOpen(false);
+  };
+
   const handleOpenLocalFile = async () => {
     try {
       const { programName, stCode } = await openSTFile();
@@ -115,6 +120,19 @@ export function OpenMenu() {
             <span className="option-text">
               <span className="option-title">Open Local File...</span>
               <span className="option-desc">Load .st file from disk</span>
+            </span>
+          </button>
+
+          <div className="open-menu-divider" />
+
+          <button
+            className="open-menu-option"
+            onClick={handleExportPdf}
+          >
+            <span className="option-icon">⬇</span>
+            <span className="option-text">
+              <span className="option-title">Export PDF…</span>
+              <span className="option-desc">Print ladder + CCW build guide</span>
             </span>
           </button>
         </div>

--- a/src/components/print-view/PrintRungSvg.tsx
+++ b/src/components/print-view/PrintRungSvg.tsx
@@ -68,7 +68,7 @@ function walkNet(
       break;
     }
     case 'comparator':
-      slots.push({ kind: 'comparator', label: `${net.operator}`, col: col.v++, row });
+      slots.push({ kind: 'comparator', label: `${net.leftOperand} ${net.operator} ${net.rightOperand}`, col: col.v++, row });
       break;
     case 'true':
       // No visual element — wire only
@@ -183,7 +183,7 @@ export function PrintRungSvg({ rung }: { rung: LadderRungIR }) {
 
   const W = RAIL * 2 + totalCols * CW + 16;
   const H = (maxRow + 1) * (CH + ROW_GAP) + ROW_GAP;
-  const cy0 = CH / 2 + ROW_GAP; // center-Y of row 0
+  const cy0 = CH / 2; // center-Y of row 0
 
   return (
     <svg

--- a/src/components/print-view/PrintRungSvg.tsx
+++ b/src/components/print-view/PrintRungSvg.tsx
@@ -24,11 +24,16 @@ const RAIL = 6;    // power rail thickness
 const FS = 9;      // font size
 
 // ============================================================================
-// Internal Slot Type
+// Internal Types
 // ============================================================================
 
+interface BusLine {
+  x1: number; y1: number;
+  x2: number; y2: number;
+}
+
 interface Slot {
-  kind: 'no' | 'nc' | 'p-contact' | 'n-contact' | 'comparator' | 'coil' | 'set-coil' | 'reset-coil' | 'timer' | 'counter' | 'wire';
+  kind: 'no' | 'nc' | 'p-contact' | 'n-contact' | 'comparator' | 'coil' | 'set-coil' | 'reset-coil' | 'timer' | 'counter';
   label: string;
   col: number;
   row: number;
@@ -43,19 +48,48 @@ function walkNet(
   col: { v: number },
   row: number,
   slots: Slot[],
+  busLines: BusLine[],
 ): void {
   switch (net.type) {
     case 'series':
-      net.elements.forEach((e) => walkNet(e, col, row, slots));
+      net.elements.forEach((e) => walkNet(e, col, row, slots, busLines));
       break;
     case 'parallel': {
       const startCol = col.v;
+      const branchEndCols: number[] = [];
       let maxUsed = 0;
+
       net.branches.forEach((b, i) => {
         const branchCol = { v: startCol };
-        walkNet(b, branchCol, row + i, slots);
+        walkNet(b, branchCol, row + i, slots, busLines);
+        branchEndCols.push(branchCol.v);
         maxUsed = Math.max(maxUsed, branchCol.v - startCol);
       });
+
+      if (net.branches.length > 1) {
+        // Vertical bus at left (entry)
+        const leftX = RAIL + startCol * CW + 12; // left edge of slot box area
+        const topCy = row * (CH + ROW_GAP) + CH / 2;
+        const botCy = (row + net.branches.length - 1) * (CH + ROW_GAP) + CH / 2;
+        busLines.push({ x1: leftX, y1: topCy, x2: leftX, y2: botCy });
+
+        // Vertical bus at right (merge)
+        const rightX = RAIL + (startCol + maxUsed) * CW + CW - 12; // right edge of slot box area
+        busLines.push({ x1: rightX, y1: topCy, x2: rightX, y2: botCy });
+
+        // Horizontal filler for short branches
+        branchEndCols.forEach((endCol, i) => {
+          if (endCol < startCol + maxUsed) {
+            const fillerY = (row + i) * (CH + ROW_GAP) + CH / 2;
+            const fillerX1 = RAIL + endCol * CW + CW - 12; // after last slot's right wire
+            const fillerX2 = rightX;
+            if (fillerX2 > fillerX1) {
+              busLines.push({ x1: fillerX1, y1: fillerY, x2: fillerX2, y2: fillerY });
+            }
+          }
+        });
+      }
+
       col.v = startCol + maxUsed;
       break;
     }
@@ -67,9 +101,14 @@ function walkNet(
       slots.push({ kind, label: net.variable, col: col.v++, row });
       break;
     }
-    case 'comparator':
-      slots.push({ kind: 'comparator', label: `${net.leftOperand} ${net.operator} ${net.rightOperand}`, col: col.v++, row });
+    case 'comparator': {
+      const opSymbol: Record<string, string> = {
+        EQ: '=', NE: '≠', GT: '>', GE: '≥', LT: '<', LE: '≤',
+      };
+      const sym = opSymbol[net.operator] ?? net.operator;
+      slots.push({ kind: 'comparator', label: `${net.leftOperand} ${sym} ${net.rightOperand}`, col: col.v++, row });
       break;
+    }
     case 'true':
       // No visual element — wire only
       break;
@@ -80,7 +119,7 @@ function walkNet(
   }
 }
 
-function outputToSlots(out: RungOutput, col: number, row: number): Slot[] {
+function outputToSlots(out: RungOutput, col: number, row: number, busLines: BusLine[]): Slot[] {
   switch (out.type) {
     case 'coil': {
       const kind: Slot['kind'] =
@@ -89,11 +128,20 @@ function outputToSlots(out: RungOutput, col: number, row: number): Slot[] {
       return [{ kind, label: out.variable, col, row }];
     }
     case 'timer':
-      return [{ kind: 'timer', label: `${out.timerType}:${out.instanceName}`, col, row }];
+      return [{ kind: 'timer', label: `${out.timerType}:${out.instanceName} ${out.presetTime}`, col, row }];
     case 'counter':
-      return [{ kind: 'counter', label: `${out.counterType}:${out.instanceName}`, col, row }];
-    case 'multi':
-      return out.outputs.flatMap((o, i) => outputToSlots(o, col, row + i));
+      return [{ kind: 'counter', label: `${out.counterType}:${out.instanceName} PV=${out.presetValue}`, col, row }];
+    case 'multi': {
+      const allSlots = out.outputs.flatMap((o, i) => outputToSlots(o, col, row + i, busLines));
+      if (out.outputs.length > 1) {
+        // Vertical connector at output column entry
+        const busX = RAIL + col * CW + 12;
+        const topCy = row * (CH + ROW_GAP) + CH / 2;
+        const botCy = (row + out.outputs.length - 1) * (CH + ROW_GAP) + CH / 2;
+        busLines.push({ x1: busX, y1: topCy, x2: busX, y2: botCy });
+      }
+      return allSlots;
+    }
     default: {
       const _exhaustive: never = out;
       void _exhaustive;
@@ -171,11 +219,12 @@ function SlotElement({ s }: { s: Slot }) {
 
 export function PrintRungSvg({ rung }: { rung: LadderRungIR }) {
   const slots: Slot[] = [];
+  const busLines: BusLine[] = [];
   const col = { v: 0 };
 
-  walkNet(rung.inputNetwork, col, 0, slots);
+  walkNet(rung.inputNetwork, col, 0, slots, busLines);
 
-  const outputSlots = outputToSlots(rung.output, col.v, 0);
+  const outputSlots = outputToSlots(rung.output, col.v, 0, busLines);
   slots.push(...outputSlots);
 
   const totalCols = col.v + 1;
@@ -197,10 +246,18 @@ export function PrintRungSvg({ rung }: { rung: LadderRungIR }) {
       {/* Wire from left rail to first element */}
       <line x1={RAIL} y1={cy0} x2={RAIL + 16} y2={cy0} stroke="#000" strokeWidth={1.5} />
 
-      {/* Rung elements */}
-      {slots.map((s, i) => (
-        <SlotElement key={i} s={s} />
+      {/* Bus lines (parallel branch connectors) */}
+      {busLines.map((l, i) => (
+        <line key={`bus-${i}`} x1={l.x1} y1={l.y1} x2={l.x2} y2={l.y2} stroke="#000" strokeWidth={1.5} />
       ))}
+
+      {/* Rung elements */}
+      {slots.map((s) => (
+        <SlotElement key={`${s.col}-${s.row}-${s.kind}`} s={s} />
+      ))}
+
+      {/* Wire from last element to right rail */}
+      <line x1={W - RAIL - 16} y1={cy0} x2={W - RAIL} y2={cy0} stroke="#000" strokeWidth={1.5} />
 
       {/* Right power rail */}
       <rect x={W - RAIL} y={0} width={RAIL} height={H} fill="#000" />

--- a/src/components/print-view/PrintRungSvg.tsx
+++ b/src/components/print-view/PrintRungSvg.tsx
@@ -73,8 +73,8 @@ function walkNet(
         const botCy = (row + net.branches.length - 1) * (CH + ROW_GAP) + CH / 2;
         busLines.push({ x1: leftX, y1: topCy, x2: leftX, y2: botCy });
 
-        // Vertical bus at right (merge)
-        const rightX = RAIL + (startCol + maxUsed) * CW + CW - 12; // right edge of slot box area
+        // Vertical bus at right (merge) — right edge of the last used column's box
+        const rightX = RAIL + (startCol + maxUsed) * CW - 12;
         busLines.push({ x1: rightX, y1: topCy, x2: rightX, y2: botCy });
 
         // Horizontal filler for short branches

--- a/src/components/print-view/PrintRungSvg.tsx
+++ b/src/components/print-view/PrintRungSvg.tsx
@@ -187,6 +187,27 @@ function SlotElement({ s }: { s: Slot }) {
   const boxW = CW - 24;
   const boxH = CH - 12;
 
+  // Comparators: split "left OP right" across two lines so operands aren't truncated
+  if (s.kind === 'comparator') {
+    const OP_SYMS = ['=', '≠', '>', '≥', '<', '≤'];
+    const parts = s.label.split(' ');
+    const opIdx = parts.findIndex((p) => OP_SYMS.includes(p));
+    const line1 = opIdx >= 0 ? parts.slice(0, opIdx + 1).join(' ') : s.label;
+    const line2 = opIdx >= 0 ? parts.slice(opIdx + 1).join(' ') : '';
+    return (
+      <g>
+        <title>{s.label}</title>
+        <line x1={x} y1={cy} x2={boxX} y2={cy} stroke="#000" strokeWidth={1.5} />
+        <rect x={boxX} y={boxY} width={boxW} height={boxH} fill="#fff" stroke="#000" strokeWidth={1.5} />
+        <text textAnchor="middle" fontFamily="monospace" fontSize={FS - 1}>
+          <tspan x={cx} y={cy - 4}>{truncate(line1, 15)}</tspan>
+          {line2 && <tspan x={cx} dy="1.2em">{truncate(line2, 15)}</tspan>}
+        </text>
+        <line x1={boxX + boxW} y1={cy} x2={x + CW} y2={cy} stroke="#000" strokeWidth={1.5} />
+      </g>
+    );
+  }
+
   return (
     <g>
       <line x1={x} y1={cy} x2={boxX} y2={cy} stroke="#000" strokeWidth={1.5} />

--- a/src/components/print-view/PrintRungSvg.tsx
+++ b/src/components/print-view/PrintRungSvg.tsx
@@ -1,0 +1,209 @@
+// src/components/print-view/PrintRungSvg.tsx
+
+/**
+ * PrintRungSvg
+ *
+ * Renders a single LadderRungIR as a compact SVG railroad diagram for
+ * inclusion in the print-view PDF export layout.
+ */
+
+import type {
+  LadderRungIR,
+  ContactNetwork,
+  RungOutput,
+} from '../../transformer/ladder-ir/ladder-ir-types';
+
+// ============================================================================
+// Layout Constants
+// ============================================================================
+
+const CW = 100; // cell width (px)
+const CH = 40;  // cell height (px)
+const ROW_GAP = 4; // gap between parallel rows
+const RAIL = 6;    // power rail thickness
+const FS = 9;      // font size
+
+// ============================================================================
+// Internal Slot Type
+// ============================================================================
+
+interface Slot {
+  kind: 'no' | 'nc' | 'p-contact' | 'n-contact' | 'comparator' | 'coil' | 'set-coil' | 'reset-coil' | 'timer' | 'counter' | 'wire';
+  label: string;
+  col: number;
+  row: number;
+}
+
+// ============================================================================
+// Network Walker
+// ============================================================================
+
+function walkNet(
+  net: ContactNetwork,
+  col: { v: number },
+  row: number,
+  slots: Slot[],
+): void {
+  switch (net.type) {
+    case 'series':
+      net.elements.forEach((e) => walkNet(e, col, row, slots));
+      break;
+    case 'parallel': {
+      const startCol = col.v;
+      let maxUsed = 0;
+      net.branches.forEach((b, i) => {
+        const branchCol = { v: startCol };
+        walkNet(b, branchCol, row + i, slots);
+        maxUsed = Math.max(maxUsed, branchCol.v - startCol);
+      });
+      col.v = startCol + maxUsed;
+      break;
+    }
+    case 'contact': {
+      const kind: Slot['kind'] =
+        net.contactType === 'NC' ? 'nc' :
+        net.contactType === 'P' ? 'p-contact' :
+        net.contactType === 'N' ? 'n-contact' : 'no';
+      slots.push({ kind, label: net.variable, col: col.v++, row });
+      break;
+    }
+    case 'comparator':
+      slots.push({ kind: 'comparator', label: `${net.operator}`, col: col.v++, row });
+      break;
+    case 'true':
+      // No visual element — wire only
+      break;
+    default: {
+      const _exhaustive: never = net;
+      void _exhaustive;
+    }
+  }
+}
+
+function outputToSlots(out: RungOutput, col: number, row: number): Slot[] {
+  switch (out.type) {
+    case 'coil': {
+      const kind: Slot['kind'] =
+        out.coilType === 'set' ? 'set-coil' :
+        out.coilType === 'reset' ? 'reset-coil' : 'coil';
+      return [{ kind, label: out.variable, col, row }];
+    }
+    case 'timer':
+      return [{ kind: 'timer', label: `${out.timerType}:${out.instanceName}`, col, row }];
+    case 'counter':
+      return [{ kind: 'counter', label: `${out.counterType}:${out.instanceName}`, col, row }];
+    case 'multi':
+      return out.outputs.flatMap((o, i) => outputToSlots(o, col, row + i));
+    default: {
+      const _exhaustive: never = out;
+      void _exhaustive;
+      return [];
+    }
+  }
+}
+
+// ============================================================================
+// Slot Renderer
+// ============================================================================
+
+function truncate(s: string, max: number = 13): string {
+  return s.length > max ? s.slice(0, max - 1) + '…' : s;
+}
+
+function SlotElement({ s }: { s: Slot }) {
+  const x = RAIL + s.col * CW;
+  const y = s.row * (CH + ROW_GAP);
+  const cx = x + CW / 2;
+  const cy = y + CH / 2;
+  const lbl = truncate(s.label);
+
+  if (s.kind === 'coil' || s.kind === 'set-coil' || s.kind === 'reset-coil') {
+    const prefix = s.kind === 'set-coil' ? 'S ' : s.kind === 'reset-coil' ? 'R ' : '';
+    const rx = CW / 2 - 12;
+    const ry = CH / 2 - 6;
+    return (
+      <g>
+        <line x1={x} y1={cy} x2={x + 12} y2={cy} stroke="#000" strokeWidth={1.5} />
+        <ellipse cx={cx} cy={cy} rx={rx} ry={ry} fill="#fff" stroke="#000" strokeWidth={1.5} />
+        <text x={cx} y={cy + 4} textAnchor="middle" fontSize={FS} fontFamily="monospace">
+          {prefix}{lbl}
+        </text>
+        <line x1={x + CW - 12} y1={cy} x2={x + CW} y2={cy} stroke="#000" strokeWidth={1.5} />
+      </g>
+    );
+  }
+
+  // Box-style elements (contacts, timers, counters, comparators)
+  const boxX = x + 12;
+  const boxY = y + 6;
+  const boxW = CW - 24;
+  const boxH = CH - 12;
+
+  return (
+    <g>
+      <line x1={x} y1={cy} x2={boxX} y2={cy} stroke="#000" strokeWidth={1.5} />
+      <rect x={boxX} y={boxY} width={boxW} height={boxH} fill="#fff" stroke="#000" strokeWidth={1.5} />
+      {s.kind === 'nc' && (
+        // Diagonal slash inside the box — marks Normally Closed contact
+        <line
+          x1={boxX + 4} y1={boxY + 4}
+          x2={boxX + 12} y2={boxY + boxH - 4}
+          stroke="#000" strokeWidth={1}
+        />
+      )}
+      <text
+        x={s.kind === 'nc' ? cx + 4 : cx}
+        y={cy + 4}
+        textAnchor="middle"
+        fontSize={FS}
+        fontFamily="monospace"
+      >
+        {lbl}
+      </text>
+      <line x1={boxX + boxW} y1={cy} x2={x + CW} y2={cy} stroke="#000" strokeWidth={1.5} />
+    </g>
+  );
+}
+
+// ============================================================================
+// Public Component
+// ============================================================================
+
+export function PrintRungSvg({ rung }: { rung: LadderRungIR }) {
+  const slots: Slot[] = [];
+  const col = { v: 0 };
+
+  walkNet(rung.inputNetwork, col, 0, slots);
+
+  const outputSlots = outputToSlots(rung.output, col.v, 0);
+  slots.push(...outputSlots);
+
+  const totalCols = col.v + 1;
+  const maxRow = slots.length > 0 ? Math.max(...slots.map((s) => s.row)) : 0;
+
+  const W = RAIL * 2 + totalCols * CW + 16;
+  const H = (maxRow + 1) * (CH + ROW_GAP) + ROW_GAP;
+  const cy0 = CH / 2 + ROW_GAP; // center-Y of row 0
+
+  return (
+    <svg
+      width={W}
+      height={H}
+      style={{ display: 'block', overflow: 'visible' }}
+      aria-label={`Rung ${rung.index + 1} ladder diagram`}
+    >
+      {/* Left power rail */}
+      <rect x={0} y={0} width={RAIL} height={H} fill="#000" />
+      {/* Wire from left rail to first element */}
+      <line x1={RAIL} y1={cy0} x2={RAIL + 16} y2={cy0} stroke="#000" strokeWidth={1.5} />
+
+      {/* Rung elements */}
+      {slots.map((s, i) => (
+        <SlotElement key={i} s={s} />
+      ))}
+
+      {/* Right power rail */}
+      <rect x={W - RAIL} y={0} width={RAIL} height={H} fill="#000" />
+    </svg>
+  );
+}

--- a/src/components/print-view/PrintView.tsx
+++ b/src/components/print-view/PrintView.tsx
@@ -57,7 +57,7 @@ export function PrintView() {
               <strong>CCW Steps:</strong>
               <ol>
                 {rungGuide.steps.map((step, si) => (
-                  <li key={si}>{step.action}</li>
+                  <li key={`${rungGuide.rungIndex}-${si}`}>{step.action}</li>
                 ))}
               </ol>
             </div>

--- a/src/components/print-view/PrintView.tsx
+++ b/src/components/print-view/PrintView.tsx
@@ -24,7 +24,13 @@ export function PrintView() {
     return result.intermediates?.ir ?? null;
   }, [content]);
 
-  if (!ir) return null;
+  if (!ir) return (
+    <div className="print-view">
+      <p style={{ fontFamily: 'Arial', color: 'red', padding: '0.5in 0.75in' }}>
+        Cannot export PDF: the active program has errors or is empty. Fix all errors before exporting.
+      </p>
+    </div>
+  );
 
   const guide = generateCcwGuide(ir);
 

--- a/src/components/print-view/PrintView.tsx
+++ b/src/components/print-view/PrintView.tsx
@@ -1,20 +1,23 @@
 /**
- * PrintView
+ * PrintView — v4
  *
- * Full-page print layout: header block + per-rung SVG railroad + CCW build guide.
- * Hidden on screen via CSS (display: none in @media screen).
- * Visible on print via CSS (display: block in @media print).
+ * Full commissioning PDF: cover + variable table (with alias) + wiring diagram +
+ * I/O checklist + Modbus register map + CCW steps + Ignition setup + gaps list.
  *
- * Uses its own transform pass (useMemo) because MainLayout keeps the transform
- * result in local state — the editor store's lastTransformResult is not populated.
+ * Manifest (research/variable-manifest.json) enriches the variable table with
+ * alias, terminal, Modbus, and device data and drives the wiring diagram.
+ * Without a manifest, falls back to v1 behaviour (raw names only).
  */
 
-import { useMemo } from 'react';
+import { useMemo, useEffect, useState } from 'react';
 import { useEditorStore } from '../../store';
 import { transformSTToLadder } from '../../transformer';
 import { generateCcwGuide } from '../../services/ccw-guide-generator';
 import { PrintRungSvg } from './PrintRungSvg';
+import { WiringDiagram } from '../wiring-diagram/WiringDiagram';
+import { formatGaps } from '../../services/manifest-loader';
 import type { VariableInfo } from '../../transformer/ladder-ir/ladder-ir-types';
+import type { VariableDeclaration, VariableManifest } from '../../models/plc-types';
 
 function scopeLabel(scope: string): string {
   switch (scope) {
@@ -31,91 +34,209 @@ function rungList(info: VariableInfo): string {
   return nums.join(', ');
 }
 
-function PrintVariableTable({ variables }: { variables: Map<string, VariableInfo> }) {
+function enriched(v: VariableInfo, manifest: VariableManifest | null): VariableDeclaration | null {
+  if (!manifest) return null;
+  return manifest.variables.find((m) => m.name === v.name) ?? null;
+}
+
+const th: React.CSSProperties = { textAlign: 'left', borderBottom: '1pt solid #000', paddingBottom: '2pt', paddingRight: '10pt', whiteSpace: 'nowrap', fontSize: '7pt' };
+const td: React.CSSProperties = { paddingRight: '10pt', paddingTop: '2pt', verticalAlign: 'top', fontSize: '7pt' };
+const mono: React.CSSProperties = { fontFamily: "'Courier New', monospace" };
+
+function PrintVariableTable({ variables, manifest }: { variables: Map<string, VariableInfo>; manifest: VariableManifest | null }) {
   const io: VariableInfo[] = [];
   const user: VariableInfo[] = [];
-
   for (const v of variables.values()) {
-    if (v.name.startsWith('_IO_EM_')) {
-      io.push(v);
-    } else {
-      user.push(v);
-    }
+    (v.name.startsWith('_IO_EM_') ? io : user).push(v);
   }
-
   io.sort((a, b) => a.name.localeCompare(b.name));
   user.sort((a, b) => a.name.localeCompare(b.name));
+  const hasManifest = manifest !== null;
 
-  const th: React.CSSProperties = { textAlign: 'left', borderBottom: '1pt solid #000', paddingBottom: '2pt', paddingRight: '12pt', whiteSpace: 'nowrap' };
-  const td: React.CSSProperties = { paddingRight: '12pt', paddingTop: '2pt', verticalAlign: 'top', whiteSpace: 'nowrap' };
-  const mono: React.CSSProperties = { fontFamily: "'Courier New', monospace" };
+  const renderTable = (rows: VariableInfo[]) => (
+    <table className="print-var-tbl">
+      <thead>
+        <tr>
+          <th style={th}>Name</th>
+          {hasManifest && <th style={th}>Alias</th>}
+          <th style={th}>Type</th>
+          <th style={th}>Scope</th>
+          {hasManifest && <th style={th}>Address</th>}
+          {hasManifest && <th style={th}>Modbus</th>}
+          {hasManifest && <th style={th}>Terminal</th>}
+          {hasManifest && <th style={th}>Device</th>}
+          <th style={th}>Rungs</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows.map((v) => {
+          const m = enriched(v, manifest);
+          return (
+            <tr key={v.name}>
+              <td style={{ ...td, ...mono }}>{v.name}</td>
+              {hasManifest && <td style={td}>{m?.alias ?? <em style={{ color: '#ef4444' }}>MISSING</em>}</td>}
+              <td style={{ ...td, ...mono }}>{v.dataType}</td>
+              <td style={td}>{scopeLabel(v.scope)}</td>
+              {hasManifest && <td style={{ ...td, ...mono }}>{m?.address ?? '—'}</td>}
+              {hasManifest && <td style={{ ...td, ...mono }}>{m?.modbusAddress ?? '—'}</td>}
+              {hasManifest && <td style={{ ...td, ...mono }}>{m?.terminalLabel ?? '—'}</td>}
+              {hasManifest && <td style={td}>{m?.sourceDevice ?? '—'}</td>}
+              <td style={td}>{rungList(v)}</td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
 
   return (
     <div className="print-variable-table">
-      <h2>Variable Reference</h2>
-
-      <p className="print-var-note">
-        <strong>User variables</strong> — add each to the Controller Global Variable table in CCW
-        (Controller Organizer → Micro820 → Global Variables → Add).
-        <strong> Physical I/O</strong> (<code>_IO_EM_*</code>) is auto-declared from the I/O
-        configuration — do <em>not</em> add these manually.
-      </p>
-
+      <h2>Variable Reference Table</h2>
       {user.length > 0 && (
         <>
           <p className="print-var-section-label">User Variables (declare in Global Variable table)</p>
-          <table className="print-var-tbl">
-            <thead>
-              <tr>
-                <th style={th}>Name</th>
-                <th style={th}>Data Type</th>
-                <th style={th}>Scope</th>
-                <th style={th}>Used in Rungs</th>
-              </tr>
-            </thead>
-            <tbody>
-              {user.map((v) => (
-                <tr key={v.name}>
-                  <td style={{ ...td, ...mono }}>{v.name}</td>
-                  <td style={{ ...td, ...mono }}>{v.dataType}</td>
-                  <td style={td}>{scopeLabel(v.scope)}</td>
-                  <td style={td}>{rungList(v)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          {renderTable(user)}
         </>
       )}
-
       {io.length > 0 && (
         <>
-          <p className="print-var-section-label">Physical I/O (auto-declared — do not add manually)</p>
-          <table className="print-var-tbl">
-            <thead>
-              <tr>
-                <th style={th}>Name</th>
-                <th style={th}>Data Type</th>
-                <th style={th}>Used in Rungs</th>
-              </tr>
-            </thead>
-            <tbody>
-              {io.map((v) => (
-                <tr key={v.name}>
-                  <td style={{ ...td, ...mono }}>{v.name}</td>
-                  <td style={{ ...td, ...mono }}>{v.dataType}</td>
-                  <td style={td}>{rungList(v)}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+          <p className="print-var-section-label">Physical I/O — auto-declared, do not add manually</p>
+          {renderTable(io)}
         </>
       )}
     </div>
   );
 }
 
+function IOChecklist({ manifest }: { manifest: VariableManifest }) {
+  const wired = manifest.variables.filter((v) => v.direction && v.terminalLabel);
+  if (wired.length === 0) return null;
+  return (
+    <div className="print-section">
+      <h2>I/O Wiring Checklist</h2>
+      <p style={{ fontSize: '7pt', marginBottom: 8 }}>Wire each row, power up, then verify signal in CCW Monitor.</p>
+      <table className="print-var-tbl">
+        <thead>
+          <tr>
+            <th style={th}>Dir</th>
+            <th style={th}>Terminal</th>
+            <th style={th}>Variable</th>
+            <th style={th}>Alias</th>
+            <th style={th}>Device</th>
+            <th style={th}>Done</th>
+          </tr>
+        </thead>
+        <tbody>
+          {wired.map((v) => (
+            <tr key={v.name}>
+              <td style={{ ...td, color: v.direction === 'IN' ? '#2563EB' : '#EA580C', fontWeight: 'bold' }}>{v.direction}</td>
+              <td style={{ ...td, ...mono }}>{v.terminalLabel}</td>
+              <td style={{ ...td, ...mono }}>{v.name}</td>
+              <td style={td}>{v.alias ?? '—'}</td>
+              <td style={td}>{v.sourceDevice ?? '—'}</td>
+              <td style={{ ...td, width: 24 }}>□</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function ModbusMap({ manifest }: { manifest: VariableManifest }) {
+  const modbus = manifest.variables.filter((v) => v.modbusAddress);
+  if (modbus.length === 0) return null;
+  return (
+    <div className="print-section">
+      <h2>Modbus Register Map</h2>
+      <p style={{ fontSize: '7pt', marginBottom: 8 }}>Micro 820 Modbus/TCP — configure Ignition Modbus driver to these addresses.</p>
+      <table className="print-var-tbl">
+        <thead>
+          <tr>
+            <th style={th}>Modbus Address</th>
+            <th style={th}>Variable</th>
+            <th style={th}>Alias</th>
+            <th style={th}>Type</th>
+            <th style={th}>R/W</th>
+          </tr>
+        </thead>
+        <tbody>
+          {modbus.sort((a, b) => (a.modbusAddress ?? '').localeCompare(b.modbusAddress ?? '')).map((v) => (
+            <tr key={v.name}>
+              <td style={{ ...td, ...mono }}>{v.modbusAddress}</td>
+              <td style={{ ...td, ...mono }}>{v.name}</td>
+              <td style={td}>{v.alias ?? '—'}</td>
+              <td style={{ ...td, ...mono }}>{v.dataType}</td>
+              <td style={td}>{v.direction === 'OUT' ? 'R/W' : 'R'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function IgnitionSetup({ manifest }: { manifest: VariableManifest }) {
+  const vars = manifest.variables.filter((v) => v.sourceDevice === 'Ignition' || v.modbusAddress);
+  return (
+    <div className="print-section">
+      <h2>Ignition Tag Setup</h2>
+      <p style={{ fontSize: '7pt', marginBottom: 4 }}>Gateway: app.factorylm.com/hub · Driver: Micro800 (CIP) · Provider: [Micro800]</p>
+      <table className="print-var-tbl">
+        <thead>
+          <tr>
+            <th style={th}>Tag Path</th>
+            <th style={th}>Alias</th>
+            <th style={th}>Type</th>
+            <th style={th}>Access</th>
+          </tr>
+        </thead>
+        <tbody>
+          {vars.map((v) => (
+            <tr key={v.name}>
+              <td style={{ ...td, ...mono }}>[Micro800]{v.name}</td>
+              <td style={td}>{v.alias ?? '—'}</td>
+              <td style={{ ...td, ...mono }}>{v.dataType}</td>
+              <td style={td}>{v.direction === 'IN' ? 'Read' : 'Read/Write'}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function GapsSection({ manifest }: { manifest: VariableManifest }) {
+  const lines = formatGaps(manifest);
+  if (lines.length === 0) return (
+    <div className="print-section">
+      <h2>Gaps / Unresolved</h2>
+      <p style={{ fontSize: '8pt', color: '#16a34a' }}>All variables fully resolved — no gaps.</p>
+    </div>
+  );
+  return (
+    <div className="print-section">
+      <h2>Gaps / Unresolved ({lines.length})</h2>
+      <p style={{ fontSize: '7pt', marginBottom: 8, color: '#dc2626' }}>
+        Resolve by physical inspection or checking the CCW project.
+      </p>
+      <ul style={{ fontSize: '7pt', paddingLeft: 16 }}>
+        {lines.map((l, i) => <li key={i} style={{ marginBottom: 2 }}>{l}</li>)}
+      </ul>
+    </div>
+  );
+}
+
 export function PrintView() {
   const content = useEditorStore((s) => s.getActiveFile()?.content);
+  const [manifest, setManifest] = useState<VariableManifest | null>(null);
+
+  useEffect(() => {
+    fetch('/research/variable-manifest.json')
+      .then((r) => r.ok ? r.json() : null)
+      .then((m) => m && setManifest(m as VariableManifest))
+      .catch(() => {});
+  }, []);
 
   const ir = useMemo(() => {
     if (!content) return null;
@@ -132,45 +253,64 @@ export function PrintView() {
   );
 
   const guide = generateCcwGuide(ir);
+  const manifestVars = manifest?.variables ?? [];
 
   return (
     <div className="print-view">
       <div className="print-header">
-        <h1>Ladder Program: {ir.programName}</h1>
+        <h1>Micro 820 Conveyor System — Commissioning Guide</h1>
+        <h2 style={{ fontWeight: 400, marginTop: 4 }}>Program: {ir.programName}</h2>
         <p className="print-meta">
           Generated {new Date().toLocaleDateString()} &middot; {ir.rungs.length} rungs &middot;
-          Target: Allen-Bradley Micro820 2080-LC20-20QBB (CCW Ladder Editor)
+          Target: Allen-Bradley Micro820 2080-LC20-20QBB &middot; CCW 22
+          {manifest && <> &middot; Manifest: {manifest.generatedAt.slice(0, 10)}</>}
         </p>
         <p className="print-instructions">
-          Transcribe each rung into CCW&apos;s LD editor. Variables are already declared in the
-          Controller Global Variable table &mdash; do <em>not</em> redeclare them.
+          Follow sections in order: wire I/O, load program in CCW, verify each point, configure Ignition tags.
         </p>
       </div>
 
-      <PrintVariableTable variables={ir.variables} />
+      <PrintVariableTable variables={ir.variables} manifest={manifest} />
 
-      {guide.map((rungGuide, i) => {
-        const rung = ir.rungs[i];
-        return (
-          <div key={rungGuide.rungIndex} className="print-rung">
-            <h3>
-              Rung {rungGuide.rungIndex + 1}
-              {rungGuide.comment ? ` \u2014 ${rungGuide.comment}` : ''}
-            </h3>
-            <div className="print-rung-visual">
-              <PrintRungSvg rung={rung} />
+      {manifestVars.some((v) => v.terminalLabel) && (
+        <div className="print-section print-page-break">
+          <h2>Wiring Diagram</h2>
+          <p style={{ fontSize: '7pt', marginBottom: 8 }}>
+            Auto-generated from variable manifest. Blue = Input, Orange = Output.
+          </p>
+          <WiringDiagram variables={manifestVars} width={680} />
+        </div>
+      )}
+
+      {manifest && <IOChecklist manifest={manifest} />}
+      {manifest && <ModbusMap manifest={manifest} />}
+
+      <div className="print-section print-page-break">
+        <h2>CCW Ladder Entry — Step by Step</h2>
+        {guide.map((rungGuide, i) => {
+          const rung = ir.rungs[i];
+          return (
+            <div key={rungGuide.rungIndex} className="print-rung">
+              <h3>
+                Rung {rungGuide.rungIndex + 1}
+                {rungGuide.comment ? ` — ${rungGuide.comment}` : ''}
+              </h3>
+              <div className="print-rung-visual"><PrintRungSvg rung={rung} /></div>
+              <div className="print-rung-guide">
+                <strong>Steps:</strong>
+                <ol>
+                  {rungGuide.steps.map((step, si) => (
+                    <li key={`${rungGuide.rungIndex}-${si}`}>{step.action}</li>
+                  ))}
+                </ol>
+              </div>
             </div>
-            <div className="print-rung-guide">
-              <strong>CCW Steps:</strong>
-              <ol>
-                {rungGuide.steps.map((step, si) => (
-                  <li key={`${rungGuide.rungIndex}-${si}`}>{step.action}</li>
-                ))}
-              </ol>
-            </div>
-          </div>
-        );
-      })}
+          );
+        })}
+      </div>
+
+      {manifest && <IgnitionSetup manifest={manifest} />}
+      {manifest && <GapsSection manifest={manifest} />}
     </div>
   );
 }

--- a/src/components/print-view/PrintView.tsx
+++ b/src/components/print-view/PrintView.tsx
@@ -14,6 +14,105 @@ import { useEditorStore } from '../../store';
 import { transformSTToLadder } from '../../transformer';
 import { generateCcwGuide } from '../../services/ccw-guide-generator';
 import { PrintRungSvg } from './PrintRungSvg';
+import type { VariableInfo } from '../../transformer/ladder-ir/ladder-ir-types';
+
+function scopeLabel(scope: string): string {
+  switch (scope) {
+    case 'VAR_INPUT':  return 'Input';
+    case 'VAR_OUTPUT': return 'Output';
+    case 'VAR_TEMP':   return 'Temp';
+    case 'VAR_GLOBAL': return 'Global';
+    default:           return 'Internal';
+  }
+}
+
+function rungList(info: VariableInfo): string {
+  const nums = [...new Set(info.usages.map((u) => u.rungIndex + 1))].sort((a, b) => a - b);
+  return nums.join(', ');
+}
+
+function PrintVariableTable({ variables }: { variables: Map<string, VariableInfo> }) {
+  const io: VariableInfo[] = [];
+  const user: VariableInfo[] = [];
+
+  for (const v of variables.values()) {
+    if (v.name.startsWith('_IO_EM_')) {
+      io.push(v);
+    } else {
+      user.push(v);
+    }
+  }
+
+  io.sort((a, b) => a.name.localeCompare(b.name));
+  user.sort((a, b) => a.name.localeCompare(b.name));
+
+  const th: React.CSSProperties = { textAlign: 'left', borderBottom: '1pt solid #000', paddingBottom: '2pt', paddingRight: '12pt', whiteSpace: 'nowrap' };
+  const td: React.CSSProperties = { paddingRight: '12pt', paddingTop: '2pt', verticalAlign: 'top', whiteSpace: 'nowrap' };
+  const mono: React.CSSProperties = { fontFamily: "'Courier New', monospace" };
+
+  return (
+    <div className="print-variable-table">
+      <h2>Variable Reference</h2>
+
+      <p className="print-var-note">
+        <strong>User variables</strong> — add each to the Controller Global Variable table in CCW
+        (Controller Organizer → Micro820 → Global Variables → Add).
+        <strong> Physical I/O</strong> (<code>_IO_EM_*</code>) is auto-declared from the I/O
+        configuration — do <em>not</em> add these manually.
+      </p>
+
+      {user.length > 0 && (
+        <>
+          <p className="print-var-section-label">User Variables (declare in Global Variable table)</p>
+          <table className="print-var-tbl">
+            <thead>
+              <tr>
+                <th style={th}>Name</th>
+                <th style={th}>Data Type</th>
+                <th style={th}>Scope</th>
+                <th style={th}>Used in Rungs</th>
+              </tr>
+            </thead>
+            <tbody>
+              {user.map((v) => (
+                <tr key={v.name}>
+                  <td style={{ ...td, ...mono }}>{v.name}</td>
+                  <td style={{ ...td, ...mono }}>{v.dataType}</td>
+                  <td style={td}>{scopeLabel(v.scope)}</td>
+                  <td style={td}>{rungList(v)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+
+      {io.length > 0 && (
+        <>
+          <p className="print-var-section-label">Physical I/O (auto-declared — do not add manually)</p>
+          <table className="print-var-tbl">
+            <thead>
+              <tr>
+                <th style={th}>Name</th>
+                <th style={th}>Data Type</th>
+                <th style={th}>Used in Rungs</th>
+              </tr>
+            </thead>
+            <tbody>
+              {io.map((v) => (
+                <tr key={v.name}>
+                  <td style={{ ...td, ...mono }}>{v.name}</td>
+                  <td style={{ ...td, ...mono }}>{v.dataType}</td>
+                  <td style={td}>{rungList(v)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </>
+      )}
+    </div>
+  );
+}
 
 export function PrintView() {
   const content = useEditorStore((s) => s.getActiveFile()?.content);
@@ -47,6 +146,8 @@ export function PrintView() {
           Controller Global Variable table &mdash; do <em>not</em> redeclare them.
         </p>
       </div>
+
+      <PrintVariableTable variables={ir.variables} />
 
       {guide.map((rungGuide, i) => {
         const rung = ir.rungs[i];

--- a/src/components/print-view/PrintView.tsx
+++ b/src/components/print-view/PrintView.tsx
@@ -1,0 +1,69 @@
+/**
+ * PrintView
+ *
+ * Full-page print layout: header block + per-rung SVG railroad + CCW build guide.
+ * Hidden on screen via CSS (display: none in @media screen).
+ * Visible on print via CSS (display: block in @media print).
+ *
+ * Uses its own transform pass (useMemo) because MainLayout keeps the transform
+ * result in local state — the editor store's lastTransformResult is not populated.
+ */
+
+import { useMemo } from 'react';
+import { useEditorStore } from '../../store';
+import { transformSTToLadder } from '../../transformer';
+import { generateCcwGuide } from '../../services/ccw-guide-generator';
+import { PrintRungSvg } from './PrintRungSvg';
+
+export function PrintView() {
+  const content = useEditorStore((s) => s.getActiveFile()?.content);
+
+  const ir = useMemo(() => {
+    if (!content) return null;
+    const result = transformSTToLadder(content, { includeIntermediates: true });
+    return result.intermediates?.ir ?? null;
+  }, [content]);
+
+  if (!ir) return null;
+
+  const guide = generateCcwGuide(ir);
+
+  return (
+    <div className="print-view">
+      <div className="print-header">
+        <h1>Ladder Program: {ir.programName}</h1>
+        <p className="print-meta">
+          Generated {new Date().toLocaleDateString()} &middot; {ir.rungs.length} rungs &middot;
+          Target: Allen-Bradley Micro820 2080-LC20-20QBB (CCW Ladder Editor)
+        </p>
+        <p className="print-instructions">
+          Transcribe each rung into CCW&apos;s LD editor. Variables are already declared in the
+          Controller Global Variable table &mdash; do <em>not</em> redeclare them.
+        </p>
+      </div>
+
+      {guide.map((rungGuide, i) => {
+        const rung = ir.rungs[i];
+        return (
+          <div key={rungGuide.rungIndex} className="print-rung">
+            <h3>
+              Rung {rungGuide.rungIndex + 1}
+              {rungGuide.comment ? ` \u2014 ${rungGuide.comment}` : ''}
+            </h3>
+            <div className="print-rung-visual">
+              <PrintRungSvg rung={rung} />
+            </div>
+            <div className="print-rung-guide">
+              <strong>CCW Steps:</strong>
+              <ol>
+                {rungGuide.steps.map((step, si) => (
+                  <li key={si}>{step.action}</li>
+                ))}
+              </ol>
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/variable-watch/VariableWatch.css
+++ b/src/components/variable-watch/VariableWatch.css
@@ -426,6 +426,98 @@
 }
 
 /* ============================================================================
+   AB-Style Variable Table (BOOL and NUM tabs)
+   ============================================================================ */
+
+.ab-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 10px;
+}
+
+.ab-th {
+  padding: 4px 6px;
+  text-align: left;
+  font-weight: 600;
+  color: var(--color-muted-foreground);
+  border-bottom: 1px solid var(--color-border);
+  white-space: nowrap;
+  text-transform: uppercase;
+  font-size: 9px;
+  letter-spacing: 0.4px;
+}
+
+.ab-row:nth-child(even) {
+  background: var(--color-elevated);
+}
+
+.ab-row:hover {
+  background: var(--color-toolbar);
+}
+
+.ab-td {
+  padding: 3px 6px;
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 40%, transparent);
+  vertical-align: middle;
+}
+
+.ab-name {
+  font-family: var(--font-mono);
+  color: var(--color-info);
+  font-size: 10px;
+  white-space: nowrap;
+}
+
+.ab-alias {
+  color: var(--color-foreground);
+  max-width: 100px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 10px;
+}
+
+.ab-mono {
+  font-family: var(--font-mono);
+  color: var(--color-muted);
+  font-size: 9px;
+  white-space: nowrap;
+}
+
+.ab-dir {
+  font-size: 9px;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.ab-dir.in {
+  color: var(--color-info);
+}
+
+.ab-dir.out {
+  color: var(--color-success);
+}
+
+.ab-type {
+  font-family: var(--font-mono);
+  color: var(--color-accent);
+  font-size: 9px;
+}
+
+.ab-val {
+  white-space: nowrap;
+}
+
+/* Column width hints */
+.ab-th-name  { min-width: 80px; }
+.ab-th-alias { min-width: 60px; }
+.ab-th-addr  { min-width: 52px; }
+.ab-th-modbus { min-width: 52px; }
+.ab-th-dir   { min-width: 28px; }
+.ab-th-type  { min-width: 32px; }
+.ab-th-val   { min-width: 56px; }
+
+/* ============================================================================
    Mobile Layout Override (Phase 5)
    ========================================================================= */
 

--- a/src/components/variable-watch/VariableWatch.tsx
+++ b/src/components/variable-watch/VariableWatch.tsx
@@ -7,7 +7,8 @@
  */
 
 import { memo, useCallback, useState } from 'react';
-import { useSimulationStore } from '../../store';
+import { useSimulationStore, useProjectStore } from '../../store';
+import type { ManifestEntry } from '../../store/project-store';
 import type { TimerState, CounterState } from '../../store/simulation-store';
 import type { LadderNode, LadderNodeData } from '../../models/ladder-elements';
 
@@ -27,6 +28,9 @@ export const VariableWatch = memo(function VariableWatch({
   // Only show properties tab when selectedNode prop is explicitly provided (mobile layout)
   const showPropertiesTab = selectedNode !== undefined && selectedNode !== null;
   const [activeTab, setActiveTab] = useState<'booleans' | 'numbers' | 'timers' | 'counters' | 'properties'>('booleans');
+
+  // Manifest metadata (alias/address/Modbus loaded via Manifest button)
+  const manifestMetadata = useProjectStore((state) => state.manifestMetadata);
 
   // Simulation state
   const booleans = useSimulationStore((state) => state.booleans);
@@ -117,6 +121,7 @@ export const VariableWatch = memo(function VariableWatch({
         {activeTab === 'booleans' && (
           <BooleanVariables
             variables={booleans}
+            metadata={manifestMetadata}
             onToggle={(name) => setBool(name, !booleans[name])}
           />
         )}
@@ -124,6 +129,7 @@ export const VariableWatch = memo(function VariableWatch({
           <NumberVariables
             integers={integers}
             reals={reals}
+            metadata={manifestMetadata}
             onSetInt={setInt}
             onSetReal={setReal}
           />
@@ -158,11 +164,13 @@ export const VariableWatch = memo(function VariableWatch({
 
 interface BooleanVariablesProps {
   variables: Record<string, boolean>;
+  metadata: Record<string, ManifestEntry>;
   onToggle: (name: string) => void;
 }
 
 const BooleanVariables = memo(function BooleanVariables({
   variables,
+  metadata,
   onToggle,
 }: BooleanVariablesProps) {
   const entries = Object.entries(variables);
@@ -172,19 +180,40 @@ const BooleanVariables = memo(function BooleanVariables({
   }
 
   return (
-    <div className="watch-list">
-      {entries.map(([name, value]) => (
-        <div key={name} className="watch-item bool-item">
-          <span className="item-name">{name}</span>
-          <button
-            className={`bool-toggle ${value ? 'on' : 'off'}`}
-            onClick={() => onToggle(name)}
-          >
-            {value ? 'TRUE' : 'FALSE'}
-          </button>
-        </div>
-      ))}
-    </div>
+    <table className="ab-table">
+      <thead>
+        <tr>
+          <th className="ab-th ab-th-name">Name</th>
+          <th className="ab-th ab-th-alias">Alias</th>
+          <th className="ab-th ab-th-addr">AT Addr</th>
+          <th className="ab-th ab-th-modbus">Modbus</th>
+          <th className="ab-th ab-th-dir">Dir</th>
+          <th className="ab-th ab-th-val">Value</th>
+        </tr>
+      </thead>
+      <tbody>
+        {entries.map(([name, value]) => {
+          const m = metadata[name];
+          return (
+            <tr key={name} className="ab-row">
+              <td className="ab-td ab-name">{name}</td>
+              <td className="ab-td ab-alias" title={m?.alias ?? undefined}>{m?.alias ?? '—'}</td>
+              <td className="ab-td ab-mono">{m?.address ?? '—'}</td>
+              <td className="ab-td ab-mono">{m?.modbusAddress ?? '—'}</td>
+              <td className={`ab-td ab-dir ${m?.direction?.toLowerCase() ?? ''}`}>{m?.direction ?? '—'}</td>
+              <td className="ab-td ab-val">
+                <button
+                  className={`bool-toggle ${value ? 'on' : 'off'}`}
+                  onClick={() => onToggle(name)}
+                >
+                  {value ? 'TRUE' : 'FALSE'}
+                </button>
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
   );
 });
 
@@ -195,6 +224,7 @@ const BooleanVariables = memo(function BooleanVariables({
 interface NumberVariablesProps {
   integers: Record<string, number>;
   reals: Record<string, number>;
+  metadata: Record<string, ManifestEntry>;
   onSetInt: (name: string, value: number) => void;
   onSetReal: (name: string, value: number) => void;
 }
@@ -202,6 +232,7 @@ interface NumberVariablesProps {
 const NumberVariables = memo(function NumberVariables({
   integers,
   reals,
+  metadata,
   onSetInt,
   onSetReal,
 }: NumberVariablesProps) {
@@ -212,39 +243,57 @@ const NumberVariables = memo(function NumberVariables({
     return <div className="watch-empty">No numeric variables</div>;
   }
 
+  const allEntries: [string, number, 'INT' | 'REAL'][] = [
+    ...intEntries.map(([n, v]) => [n, v, 'INT'] as [string, number, 'INT']),
+    ...realEntries.map(([n, v]) => [n, v, 'REAL'] as [string, number, 'REAL']),
+  ];
+
   return (
-    <div className="watch-list">
-      {intEntries.map(([name, value]) => (
-        <NumberInput
-          key={name}
-          name={name}
-          value={value}
-          type="INT"
-          onChange={(v) => onSetInt(name, Math.floor(v))}
-        />
-      ))}
-      {realEntries.map(([name, value]) => (
-        <NumberInput
-          key={name}
-          name={name}
-          value={value}
-          type="REAL"
-          onChange={(v) => onSetReal(name, v)}
-        />
-      ))}
-    </div>
+    <table className="ab-table">
+      <thead>
+        <tr>
+          <th className="ab-th ab-th-name">Name</th>
+          <th className="ab-th ab-th-alias">Alias</th>
+          <th className="ab-th ab-th-addr">AT Addr</th>
+          <th className="ab-th ab-th-modbus">Modbus</th>
+          <th className="ab-th ab-th-dir">Dir</th>
+          <th className="ab-th ab-th-type">Type</th>
+          <th className="ab-th ab-th-val">Value</th>
+        </tr>
+      </thead>
+      <tbody>
+        {allEntries.map(([name, value, type]) => {
+          const m = metadata[name];
+          return (
+            <tr key={name} className="ab-row">
+              <td className="ab-td ab-name">{name}</td>
+              <td className="ab-td ab-alias" title={m?.alias ?? undefined}>{m?.alias ?? '—'}</td>
+              <td className="ab-td ab-mono">{m?.address ?? '—'}</td>
+              <td className="ab-td ab-mono">{m?.modbusAddress ?? '—'}</td>
+              <td className={`ab-td ab-dir ${m?.direction?.toLowerCase() ?? ''}`}>{m?.direction ?? '—'}</td>
+              <td className="ab-td ab-type">{type}</td>
+              <td className="ab-td ab-val">
+                <NumberInput
+                  value={value}
+                  type={type}
+                  onChange={(v) => type === 'INT' ? onSetInt(name, Math.floor(v)) : onSetReal(name, v)}
+                />
+              </td>
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
   );
 });
 
 interface NumberInputProps {
-  name: string;
   value: number;
   type: 'INT' | 'REAL';
   onChange: (value: number) => void;
 }
 
 const NumberInput = memo(function NumberInput({
-  name,
   value,
   type,
   onChange,
@@ -260,32 +309,26 @@ const NumberInput = memo(function NumberInput({
     setEditing(false);
   }, [inputValue, type, onChange]);
 
-  return (
-    <div className="watch-item number-item">
-      <span className="item-name">{name}</span>
-      <span className="item-type">{type}</span>
-      {editing ? (
-        <input
-          type="number"
-          className="number-input"
-          value={inputValue}
-          onChange={(e) => setInputValue(e.target.value)}
-          onBlur={handleSubmit}
-          onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
-          autoFocus
-        />
-      ) : (
-        <span
-          className="item-value"
-          onClick={() => {
-            setInputValue(value.toString());
-            setEditing(true);
-          }}
-        >
-          {type === 'REAL' ? value.toFixed(2) : value}
-        </span>
-      )}
-    </div>
+  return editing ? (
+    <input
+      type="number"
+      className="number-input"
+      value={inputValue}
+      onChange={(e) => setInputValue(e.target.value)}
+      onBlur={handleSubmit}
+      onKeyDown={(e) => e.key === 'Enter' && handleSubmit()}
+      autoFocus
+    />
+  ) : (
+    <span
+      className="item-value"
+      onClick={() => {
+        setInputValue(value.toString());
+        setEditing(true);
+      }}
+    >
+      {type === 'REAL' ? value.toFixed(2) : value}
+    </span>
   );
 });
 

--- a/src/components/wiring-diagram/WiringDiagram.tsx
+++ b/src/components/wiring-diagram/WiringDiagram.tsx
@@ -1,0 +1,158 @@
+import type { VariableDeclaration } from "../../models/plc-types";
+
+// Layout constants
+const DEVICE_W = 140;
+const DEVICE_H = 56;
+const TB_W = 120;
+const TB_H = 28;
+const PAD = 32;
+const WIRE_COLORS = { IN: "#2563EB", OUT: "#EA580C", POWER: "#DC2626", GND: "#374151" };
+
+interface DeviceBox {
+  id: string;
+  label: string;
+  x: number;
+  y: number;
+}
+
+interface TerminalRow {
+  label: string;
+  alias: string;
+  varName: string;
+  direction: "IN" | "OUT";
+  x: number;
+  y: number;
+  deviceId: string;
+}
+
+function buildLayout(variables: VariableDeclaration[]) {
+  // Collect unique devices
+  const deviceSet = new Set<string>();
+  for (const v of variables) {
+    if (v.sourceDevice) deviceSet.add(v.sourceDevice);
+  }
+  const deviceList = ["Micro 820", ...Array.from(deviceSet).filter((d) => d !== "Micro 820")];
+
+  const deviceBoxes: DeviceBox[] = deviceList.map((d, i) => ({
+    id: d,
+    label: d,
+    x: PAD + i * (DEVICE_W + PAD * 2),
+    y: PAD,
+  }));
+
+  const totalWidth = deviceBoxes.length * (DEVICE_W + PAD * 2) + PAD;
+
+  // Assign terminal rows for wired variables
+  const wired = variables.filter(
+    (v) => v.terminalLabel && (v.direction === "IN" || v.direction === "OUT")
+  );
+
+  const terminals: TerminalRow[] = wired.map((v, i) => ({
+    label: v.terminalLabel ?? "",
+    alias: v.alias ?? v.name,
+    varName: v.name,
+    direction: v.direction as "IN" | "OUT",
+    x: PAD,
+    y: PAD + DEVICE_H + PAD + i * (TB_H + 6),
+    deviceId: v.sourceDevice ?? "Micro 820",
+  }));
+
+  const totalHeight = PAD + DEVICE_H + PAD + terminals.length * (TB_H + 6) + PAD;
+
+  return { deviceBoxes, terminals, totalWidth, totalHeight };
+}
+
+interface WiringDiagramProps {
+  variables: VariableDeclaration[];
+  width?: number;
+}
+
+export function WiringDiagram({ variables, width = 800 }: WiringDiagramProps) {
+  const { deviceBoxes, terminals, totalWidth, totalHeight } = buildLayout(variables);
+
+  const scale = width / Math.max(totalWidth, width);
+  const height = totalHeight * scale;
+
+  const textBase: React.CSSProperties = { fontFamily: "monospace", fontSize: 9 };
+
+  return (
+    <svg
+      viewBox={}
+      width={width}
+      height={height}
+      style={{ border: "1px solid #e5e7eb", borderRadius: 4, background: "#fff" }}
+    >
+      {/* Device boxes */}
+      {deviceBoxes.map((d) => (
+        <g key={d.id}>
+          <rect
+            x={d.x} y={d.y} width={DEVICE_W} height={DEVICE_H}
+            rx={6} fill="#1e40af" stroke="#1e3a8a" strokeWidth={1.5}
+          />
+          <text
+            x={d.x + DEVICE_W / 2} y={d.y + DEVICE_H / 2 + 4}
+            textAnchor="middle" fill="white"
+            style={{ ...textBase, fontSize: 10, fontWeight: "bold" }}
+          >
+            {d.label}
+          </text>
+        </g>
+      ))}
+
+      {/* Terminal rows and wires */}
+      {terminals.map((t) => {
+        const color = WIRE_COLORS[t.direction];
+        const device = deviceBoxes.find((d) => d.id === t.deviceId) ?? deviceBoxes[0];
+        const plcBox = deviceBoxes[0];
+
+        const tbX = PAD;
+        const tbY = t.y;
+        const wireFromX = t.direction === "IN" ? device.x + DEVICE_W : device.x;
+        const wireFromY = device.y + DEVICE_H / 2;
+        const wireToX = tbX + TB_W;
+        const wireToY = tbY + TB_H / 2;
+        const plcX = t.direction === "IN" ? plcBox.x : plcBox.x + DEVICE_W;
+        const plcY = plcBox.y + DEVICE_H / 2;
+
+        return (
+          <g key={t.varName}>
+            {/* Terminal block rect */}
+            <rect
+              x={tbX} y={tbY} width={TB_W} height={TB_H}
+              rx={3} fill="#f8fafc" stroke="#94a3b8" strokeWidth={1}
+            />
+            <text x={tbX + 6} y={tbY + 11} style={{ ...textBase, fill: "#475569" }}>
+              {t.label}
+            </text>
+            <text x={tbX + 6} y={tbY + 22} style={{ ...textBase, fill: "#0f172a", fontWeight: "bold" }}>
+              {t.alias.length > 18 ? t.alias.slice(0, 17) + "…" : t.alias}
+            </text>
+
+            {/* Wire: device → terminal block */}
+            <polyline
+              points={}
+              fill="none" stroke={color} strokeWidth={1.5} strokeDasharray={t.direction === "OUT" ? "4,2" : undefined}
+            />
+
+            {/* Wire: terminal block → PLC */}
+            <polyline
+              points={}
+              fill="none" stroke={color} strokeWidth={1.5} opacity={0.4}
+            />
+          </g>
+        );
+      })}
+
+      {/* Legend */}
+      {[
+        { color: WIRE_COLORS.IN, label: "Input (IN)" },
+        { color: WIRE_COLORS.OUT, label: "Output (OUT)" },
+      ].map((item, i) => (
+        <g key={item.label} transform={}>
+          <line x1={0} y1={6} x2={24} y2={6} stroke={item.color} strokeWidth={2} />
+          <text x={28} y={10} style={{ ...textBase, fill: "#374151" }}>{item.label}</text>
+        </g>
+      ))}
+    </svg>
+  );
+}

--- a/src/components/wiring-diagram/WiringDiagram.tsx
+++ b/src/components/wiring-diagram/WiringDiagram.tsx
@@ -77,7 +77,7 @@ export function WiringDiagram({ variables, width = 800 }: WiringDiagramProps) {
 
   return (
     <svg
-      viewBox={}
+      viewBox={`0 0 ${totalWidth} ${totalHeight}`}
       width={width}
       height={height}
       style={{ border: "1px solid #e5e7eb", borderRadius: 4, background: "#fff" }}
@@ -130,13 +130,13 @@ export function WiringDiagram({ variables, width = 800 }: WiringDiagramProps) {
 
             {/* Wire: device → terminal block */}
             <polyline
-              points={}
+              points={`${wireFromX},${wireFromY} ${wireToX},${wireToY}`}
               fill="none" stroke={color} strokeWidth={1.5} strokeDasharray={t.direction === "OUT" ? "4,2" : undefined}
             />
 
             {/* Wire: terminal block → PLC */}
             <polyline
-              points={}
+              points={`${wireToX},${wireToY} ${plcX},${plcY}`}
               fill="none" stroke={color} strokeWidth={1.5} opacity={0.4}
             />
           </g>
@@ -148,7 +148,7 @@ export function WiringDiagram({ variables, width = 800 }: WiringDiagramProps) {
         { color: WIRE_COLORS.IN, label: "Input (IN)" },
         { color: WIRE_COLORS.OUT, label: "Output (OUT)" },
       ].map((item, i) => (
-        <g key={item.label} transform={}>
+        <g key={item.label} transform={`translate(${PAD}, ${totalHeight - 40 + i * 20})`}>
           <line x1={0} y1={6} x2={24} y2={6} stroke={item.color} strokeWidth={2} />
           <text x={28} y={10} style={{ ...textBase, fill: "#374151" }}>{item.label}</text>
         </g>

--- a/src/hooks/useLiveBridge.ts
+++ b/src/hooks/useLiveBridge.ts
@@ -1,0 +1,77 @@
+/**
+ * useLiveBridge
+ *
+ * React hook managing the live PLC data bridge lifecycle.
+ * Reads manifest modbusAddress fields, builds polling targets,
+ * and injects values into the simulation store via setVariables().
+ */
+
+import { useState, useRef, useCallback } from 'react';
+import { useProjectStore, useSimulationStore } from '../store';
+import { startLiveBridge, parseAddress, type LiveBridgeTarget } from '../services/live-bridge';
+
+export type LiveStatus = 'off' | 'connecting' | 'live' | 'error';
+
+export function useLiveBridge() {
+  const [liveStatus, setLiveStatus] = useState<LiveStatus>('off');
+  const [liveError, setLiveError] = useState<string | undefined>(undefined);
+  const stopRef = useRef<(() => void) | null>(null);
+
+  const stopLive = useCallback(() => {
+    if (stopRef.current) {
+      stopRef.current();
+      stopRef.current = null;
+    }
+    setLiveStatus('off');
+    setLiveError(undefined);
+  }, []);
+
+  const toggleLive = useCallback(() => {
+    if (liveStatus !== 'off') {
+      stopLive();
+      return;
+    }
+
+    // Build targets from manifest — only IN-direction variables with addresses
+    const metadata = useProjectStore.getState().manifestMetadata;
+    const targets: LiveBridgeTarget[] = [];
+
+    for (const [name, entry] of Object.entries(metadata)) {
+      if (entry.direction !== 'IN') continue;
+      if (!entry.modbusAddress) continue;
+      const parsed = parseAddress(entry.modbusAddress);
+      if (!parsed) continue;
+      targets.push({ name, addressType: parsed.type, register: parsed.register });
+    }
+
+    if (targets.length === 0) {
+      setLiveStatus('error');
+      setLiveError('No IN variables with Modbus addresses found in manifest. Load a manifest first.');
+      return;
+    }
+
+    setLiveStatus('connecting');
+    setLiveError(undefined);
+
+    const stop = startLiveBridge(
+      targets,
+      {
+        onValues: (values) => {
+          useSimulationStore.getState().setVariables(values);
+        },
+        onStatus: (status, error) => {
+          if (status === 'live') setLiveStatus('live');
+          else if (status === 'connecting') setLiveStatus('connecting');
+          else if (status === 'error') {
+            setLiveStatus('error');
+            setLiveError(error);
+          }
+        },
+      }
+    );
+
+    stopRef.current = stop;
+  }, [liveStatus, stopLive]);
+
+  return { liveStatus, liveError, toggleLive, stopLive };
+}

--- a/src/index.css
+++ b/src/index.css
@@ -157,6 +157,12 @@
 }
 
 @media print {
+  /* Allow full document height to render all rungs */
+  html, body, .main-layout {
+    height: auto !important;
+    overflow: visible !important;
+  }
+
   /* Hide editor chrome */
   header, nav, aside,
   .toolbar, .file-tabs,
@@ -209,6 +215,51 @@
     font-family: 'Courier New', monospace;
   }
   .print-rung-guide li { margin-bottom: 1.5pt; }
+
+  /* Variable reference table */
+  .print-variable-table {
+    page-break-inside: avoid;
+    margin-bottom: 16pt;
+  }
+  .print-variable-table h2 {
+    font-size: 11pt;
+    margin: 0 0 4pt;
+    border-bottom: 1.5pt solid #000;
+    padding-bottom: 3pt;
+  }
+  .print-var-note {
+    font-size: 8.5pt;
+    margin: 0 0 8pt;
+    color: #333;
+  }
+  .print-var-note code {
+    font-family: 'Courier New', monospace;
+    font-size: 8pt;
+  }
+  .print-var-section-label {
+    font-size: 8.5pt;
+    font-weight: bold;
+    margin: 6pt 0 3pt;
+    color: #444;
+  }
+  .print-var-tbl {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 8.5pt;
+    margin-bottom: 4pt;
+  }
+  .print-var-tbl th,
+  .print-var-tbl td {
+    border: 0.5pt solid #bbb;
+    padding: 2pt 6pt;
+    text-align: left;
+  }
+  .print-var-tbl thead tr {
+    background: #f0f0f0;
+  }
+  .print-var-tbl tbody tr:nth-child(even) {
+    background: #fafafa;
+  }
 
   @page {
     size: letter;

--- a/src/index.css
+++ b/src/index.css
@@ -159,7 +159,7 @@
 @media print {
   /* Hide editor chrome */
   header, nav, aside,
-  .toolbar, .sidebar, .file-tabs,
+  .toolbar, .file-tabs,
   .open-menu, .help-menu,
   .react-flow__controls, .react-flow__minimap, .react-flow__panel,
   [class*="toolbar"], [class*="panel"], [class*="simulation"],

--- a/src/index.css
+++ b/src/index.css
@@ -150,3 +150,68 @@
   --mobile-transition-fast: 120ms cubic-bezier(0.4, 0, 0.2, 1);
   --mobile-transition-base: 180ms cubic-bezier(0.4, 0, 0.2, 1);
 }
+
+/* ── Print / PDF Export ─────────────────────────────────────── */
+@media screen {
+  .print-view { display: none; }
+}
+
+@media print {
+  /* Hide editor chrome */
+  header, nav, aside,
+  .toolbar, .sidebar, .file-tabs,
+  .open-menu, .help-menu,
+  .react-flow__controls, .react-flow__minimap, .react-flow__panel,
+  [class*="toolbar"], [class*="panel"], [class*="simulation"],
+  .workspace-sidebar, .status-bar, .error-panel {
+    display: none !important;
+  }
+
+  /* Hide live canvas */
+  .react-flow { display: none !important; }
+
+  /* Show print content */
+  .print-view {
+    display: block !important;
+    font-family: Arial, sans-serif;
+    font-size: 10pt;
+    color: #000;
+    background: #fff;
+  }
+
+  .print-header {
+    border-bottom: 2pt solid #000;
+    padding-bottom: 8pt;
+    margin-bottom: 14pt;
+  }
+  .print-header h1 { font-size: 15pt; margin: 0 0 4pt; }
+  .print-meta { font-size: 8pt; color: #555; margin: 0 0 3pt; }
+  .print-instructions { font-size: 9pt; font-style: italic; margin: 0; }
+
+  .print-rung {
+    page-break-inside: avoid;
+    border: 1pt solid #bbb;
+    border-radius: 3pt;
+    padding: 7pt 9pt;
+    margin-bottom: 10pt;
+  }
+  .print-rung h3 {
+    font-size: 10pt;
+    margin: 0 0 5pt;
+    border-bottom: 0.5pt solid #aaa;
+    padding-bottom: 3pt;
+  }
+  .print-rung-visual { margin: 5pt 0 6pt; }
+  .print-rung-guide ol {
+    margin: 3pt 0 0;
+    padding-left: 16pt;
+    font-size: 8.5pt;
+    font-family: 'Courier New', monospace;
+  }
+  .print-rung-guide li { margin-bottom: 1.5pt; }
+
+  @page {
+    size: letter;
+    margin: 0.75in;
+  }
+}

--- a/src/interpreter/index.ts
+++ b/src/interpreter/index.ts
@@ -32,3 +32,6 @@ export {
 
 // Program runner
 export { runScanCycle, executeOneStatement, getTotalStatementCount } from './program-runner';
+
+// Power flow
+export { evaluatePowerFlow, type PowerFlowResult } from './power-flow-evaluator';

--- a/src/interpreter/power-flow-evaluator.ts
+++ b/src/interpreter/power-flow-evaluator.ts
@@ -1,0 +1,186 @@
+/**
+ * Power Flow Evaluator
+ *
+ * After each scan cycle, walks the LadderIR contact networks with current
+ * store variable values to determine which nodes are actively passing power.
+ * Results are stored in the simulation store and consumed by node components
+ * and the canvas for real-time green highlighting.
+ */
+
+import type { LadderIR, ContactNetwork, RungOutput } from '../transformer/ladder-ir';
+import type { DiagramLayout } from '../transformer/layout';
+import type { SimulationStoreInterface } from './execution-context';
+import type { RuntimeState } from './execution-context';
+
+// ============================================================================
+// Result
+// ============================================================================
+
+export interface PowerFlowResult {
+  poweredNodeIds: Set<string>;
+  poweredEdgeIds: Set<string>;
+}
+
+// ============================================================================
+// Public Entry Point
+// ============================================================================
+
+export function evaluatePowerFlow(
+  ir: LadderIR,
+  store: SimulationStoreInterface,
+  runtimeState: RuntimeState,
+  layout: DiagramLayout
+): PowerFlowResult {
+  const poweredNodeIds = new Set<string>();
+  const poweredEdgeIds = new Set<string>();
+
+  for (let i = 0; i < ir.rungs.length; i++) {
+    const rung = ir.rungs[i];
+    const rungLayout = layout.rungLayouts[i];
+    if (!rungLayout) continue;
+
+    const { leftRailId, rightRailId } = rungLayout;
+
+    // Left rail is always powered when simulation is running
+    poweredNodeIds.add(leftRailId);
+
+    // Evaluate whether power flows through the input network
+    const rungPowered = evalNetwork(rung.inputNetwork, true, store, runtimeState, poweredNodeIds);
+
+    // Mark output node if rung is powered
+    if (rungPowered) {
+      markOutput(rung.output, poweredNodeIds);
+      poweredNodeIds.add(rightRailId);
+    }
+  }
+
+  // Color edges where both endpoints are powered
+  for (const edge of layout.edges) {
+    if (poweredNodeIds.has(edge.source) && poweredNodeIds.has(edge.target)) {
+      poweredEdgeIds.add(edge.id);
+    }
+  }
+
+  return { poweredNodeIds, poweredEdgeIds };
+}
+
+// ============================================================================
+// Network Evaluation
+// ============================================================================
+
+function evalNetwork(
+  network: ContactNetwork,
+  inputPowered: boolean,
+  store: SimulationStoreInterface,
+  runtimeState: RuntimeState,
+  poweredNodeIds: Set<string>
+): boolean {
+  switch (network.type) {
+    case 'series': {
+      let powered = inputPowered;
+      for (const element of network.elements) {
+        powered = evalNetwork(element, powered, store, runtimeState, poweredNodeIds);
+      }
+      return powered;
+    }
+
+    case 'parallel': {
+      let anyPowered = false;
+      for (const branch of network.branches) {
+        const branchPowered = evalNetwork(branch, inputPowered, store, runtimeState, poweredNodeIds);
+        if (branchPowered) anyPowered = true;
+      }
+      return anyPowered;
+    }
+
+    case 'contact': {
+      const closed = evalContact(network.variable, network.contactType, store, runtimeState);
+      const passes = inputPowered && closed;
+      if (passes && network.nodeId) poweredNodeIds.add(network.nodeId);
+      return passes;
+    }
+
+    case 'comparator': {
+      const passes = inputPowered && evalComparator(
+        network.operator,
+        network.leftOperand,
+        network.rightOperand,
+        store
+      );
+      if (passes && network.nodeId) poweredNodeIds.add(network.nodeId);
+      return passes;
+    }
+
+    case 'true':
+      return inputPowered;
+  }
+}
+
+// ============================================================================
+// Contact Evaluation
+// ============================================================================
+
+function evalContact(
+  variable: string,
+  contactType: 'NO' | 'NC' | 'P' | 'N',
+  store: SimulationStoreInterface,
+  runtimeState: RuntimeState
+): boolean {
+  const current = store.getBool(variable);
+  switch (contactType) {
+    case 'NO': return current;
+    case 'NC': return !current;
+    case 'P': return current && !(runtimeState.previousInputs[variable] ?? false);
+    case 'N': return !current && (runtimeState.previousInputs[variable] ?? false);
+  }
+}
+
+// ============================================================================
+// Comparator Evaluation
+// ============================================================================
+
+function resolveOperand(operand: string, store: SimulationStoreInterface): number {
+  const asNum = Number(operand);
+  if (!isNaN(asNum)) return asNum;
+  return store.getInt(operand) ?? store.getReal(operand) ?? 0;
+}
+
+function evalComparator(
+  operator: string,
+  left: string,
+  right: string,
+  store: SimulationStoreInterface
+): boolean {
+  const l = resolveOperand(left, store);
+  const r = resolveOperand(right, store);
+  switch (operator) {
+    case 'EQ': return l === r;
+    case 'NE': return l !== r;
+    case 'GT': return l > r;
+    case 'GE': return l >= r;
+    case 'LT': return l < r;
+    case 'LE': return l <= r;
+    default: return false;
+  }
+}
+
+// ============================================================================
+// Output Marking
+// ============================================================================
+
+function markOutput(output: RungOutput, poweredNodeIds: Set<string>): void {
+  switch (output.type) {
+    case 'coil':
+      if (output.nodeId) poweredNodeIds.add(output.nodeId);
+      break;
+    case 'timer':
+      if (output.nodeId) poweredNodeIds.add(output.nodeId);
+      break;
+    case 'counter':
+      if (output.nodeId) poweredNodeIds.add(output.nodeId);
+      break;
+    case 'multi':
+      for (const o of output.outputs) markOutput(o, poweredNodeIds);
+      break;
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -27,7 +27,7 @@ initializeOnboarding();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <HashRouter>
+    <HashRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
       <Routes>
         <Route path="/" element={<App />} />
         <Route path="/docs/*" element={<DocsLayout />} />

--- a/src/models/plc-types.ts
+++ b/src/models/plc-types.ts
@@ -122,13 +122,13 @@ export interface VariableDeclaration {
   comment?: string;
   address?: string;          // IEC hardware address (%IX0.0, %QX0.0)
 
-  // v4: Physical wiring and mapping metadata
+  // Physical wiring and mapping metadata
   alias?: string;            // Human-readable label — "E-stop NC Contact", "VFD Run Command"
   modbusAddress?: string;    // Coil/register from Modbus config — "COIL:3", "HR:1"
   retain?: boolean;          // TRUE if variable survives power cycle
   terminalLabel?: string;    // Physical terminal ID on panel — "TB1-3", "VFD-FWD"
   sourceDevice?: string;     // Device that drives/reads this — "GS10 VFD", "E-stop", "Ignition"
-  direction?: "IN" | "OUT"; // Wire direction for wiring diagram (derived from scope)
+  direction?: 'IN' | 'OUT'; // Wire direction for wiring diagram (derived from scope)
 }
 
 // Wiring manifest — output of Phase 1 Ralph Loop research

--- a/src/models/plc-types.ts
+++ b/src/models/plc-types.ts
@@ -4,32 +4,32 @@
 
 // Primitive data types
 export type PLCPrimitiveType =
-  | 'BOOL'
-  | 'INT'
-  | 'DINT'
-  | 'UINT'
-  | 'REAL'
-  | 'TIME'
-  | 'STRING';
+  | "BOOL"
+  | "INT"
+  | "DINT"
+  | "UINT"
+  | "REAL"
+  | "TIME"
+  | "STRING";
 
 // Function block types
 export type PLCFunctionBlockType =
-  | 'TON'   // On-delay timer
-  | 'TOF'   // Off-delay timer
-  | 'TP'    // Pulse timer
-  | 'CTU'   // Count up
-  | 'CTD'   // Count down
-  | 'CTUD'; // Count up/down
+  | "TON"   // On-delay timer
+  | "TOF"   // Off-delay timer
+  | "TP"    // Pulse timer
+  | "CTU"   // Count up
+  | "CTD"   // Count down
+  | "CTUD"; // Count up/down
 
 export type PLCDataType = PLCPrimitiveType | PLCFunctionBlockType;
 
 // Variable scope (IEC 61131-3)
 export type VariableScope =
-  | 'VAR'
-  | 'VAR_INPUT'
-  | 'VAR_OUTPUT'
-  | 'VAR_IN_OUT'
-  | 'VAR_TEMP';
+  | "VAR"
+  | "VAR_INPUT"
+  | "VAR_OUTPUT"
+  | "VAR_IN_OUT"
+  | "VAR_TEMP";
 
 // Time value representation
 export interface TimeValue {
@@ -47,7 +47,7 @@ export function parseTimeLiteral(literal: string): TimeValue {
   const result: TimeValue = {};
 
   // Remove prefix
-  const value = literal.replace(/^(T#|TIME#)/i, '');
+  const value = literal.replace(/^(T#|TIME#)/i, "");
 
   // Match each component
   const dayMatch = value.match(/(\d+)d/i);
@@ -112,32 +112,63 @@ export function msToTimeLiteral(ms: number): string {
   return `T#${seconds}s${remainingMs}ms`;
 }
 
-// Variable declaration
+// Variable declaration — v4 schema with full PLC mapping metadata
 export interface VariableDeclaration {
+  // Core IEC 61131-3 fields
   name: string;
   dataType: PLCDataType;
   scope: VariableScope;
   initialValue?: string;
   comment?: string;
-  address?: string; // I/O address like %IX0.0, %QX0.0
+  address?: string;          // IEC hardware address (%IX0.0, %QX0.0)
+
+  // v4: Physical wiring and mapping metadata
+  alias?: string;            // Human-readable label — "E-stop NC Contact", "VFD Run Command"
+  modbusAddress?: string;    // Coil/register from Modbus config — "COIL:3", "HR:1"
+  retain?: boolean;          // TRUE if variable survives power cycle
+  terminalLabel?: string;    // Physical terminal ID on panel — "TB1-3", "VFD-FWD"
+  sourceDevice?: string;     // Device that drives/reads this — "GS10 VFD", "E-stop", "Ignition"
+  direction?: "IN" | "OUT"; // Wire direction for wiring diagram (derived from scope)
+}
+
+// Wiring manifest — output of Phase 1 Ralph Loop research
+export interface VariableManifest {
+  generatedAt: string;
+  sourceFiles: string[];
+  variables: VariableDeclaration[];
+  wiringNotes: string[];
+  gaps: ManifestGap[];
+}
+
+export interface ManifestGap {
+  variableName: string;
+  missingFields: string[];
+  note: string;
 }
 
 // Default values for data types
 export function getDefaultValue(dataType: PLCDataType): string {
   switch (dataType) {
-    case 'BOOL':
-      return 'FALSE';
-    case 'INT':
-    case 'DINT':
-    case 'UINT':
-      return '0';
-    case 'REAL':
-      return '0.0';
-    case 'TIME':
-      return 'T#0ms';
-    case 'STRING':
+    case "BOOL":
+      return "FALSE";
+    case "INT":
+    case "DINT":
+    case "UINT":
+      return "0";
+    case "REAL":
+      return "0.0";
+    case "TIME":
+      return "T#0ms";
+    case "STRING":
       return "''";
     default:
-      return '';
+      return "";
   }
+}
+
+// Derive wire direction from IEC scope
+export function scopeToDirection(scope: VariableScope): "IN" | "OUT" | undefined {
+  if (scope === "VAR_INPUT") return "IN";
+  if (scope === "VAR_OUTPUT") return "OUT";
+  return undefined;
 }

--- a/src/services/ccw-guide-generator.ts
+++ b/src/services/ccw-guide-generator.ts
@@ -1,0 +1,106 @@
+// src/services/ccw-guide-generator.ts
+import type {
+  LadderIR,
+  LadderRungIR,
+  ContactNetwork,
+  RungOutput,
+} from '../transformer/ladder-ir/ladder-ir-types';
+
+export interface CcwStep {
+  action: string;
+}
+
+export interface CcwRungGuide {
+  rungIndex: number;
+  comment?: string;
+  steps: CcwStep[];
+}
+
+const CONTACT_LABELS: Record<string, string> = {
+  NO: 'Direct Contact (XIC)',
+  NC: 'Reverse Contact (XIO)',
+  P: 'Positive Edge Contact',
+  N: 'Negative Edge Contact',
+};
+
+const OP_LABELS: Record<string, string> = {
+  EQ: 'EQU',
+  NE: 'NEQ',
+  GT: 'GRT',
+  GE: 'GEQ',
+  LT: 'LES',
+  LE: 'LEQ',
+};
+
+const COIL_LABELS: Record<string, string> = {
+  standard: 'Direct Coil (OTE)',
+  set: 'Set Coil (OTL)',
+  reset: 'Reset Coil (OTU)',
+};
+
+function walkNetwork(net: ContactNetwork, steps: CcwStep[]): void {
+  switch (net.type) {
+    case 'series':
+      net.elements.forEach((e) => walkNetwork(e, steps));
+      break;
+    case 'parallel':
+      steps.push({ action: '↳ Open parallel branch (OR)' });
+      net.branches.forEach((b, i) => {
+        if (i > 0) steps.push({ action: '  | (next branch)' });
+        walkNetwork(b, steps);
+      });
+      steps.push({ action: '↳ Close parallel branch' });
+      break;
+    case 'contact':
+      steps.push({
+        action: `Add ${CONTACT_LABELS[net.contactType] ?? net.contactType} → bind to: ${net.variable}`,
+      });
+      break;
+    case 'comparator':
+      steps.push({
+        action: `Add ${OP_LABELS[net.operator] ?? net.operator} Instruction → Left: ${net.leftOperand}, Right: ${net.rightOperand}`,
+      });
+      break;
+    case 'true':
+      steps.push({
+        action: '(No contact needed — leave rung condition empty in CCW for unconditional execution)',
+      });
+      break;
+  }
+}
+
+function walkOutput(output: RungOutput, steps: CcwStep[]): void {
+  switch (output.type) {
+    case 'coil':
+      steps.push({
+        action: `Add ${COIL_LABELS[output.coilType] ?? output.coilType} → bind to: ${output.variable}`,
+      });
+      break;
+    case 'timer':
+      steps.push({
+        action: `Add ${output.timerType} Function Block → instance name: ${output.instanceName}`,
+      });
+      steps.push({ action: `  Set PT = ${output.presetTime}` });
+      steps.push({
+        action: `  Wire rung condition to IN pin (not EN — Micro800 TON has a distinct IN input)`,
+      });
+      break;
+    case 'counter':
+      steps.push({
+        action: `Add ${output.counterType} Function Block → instance name: ${output.instanceName}, PV = ${output.presetValue}`,
+      });
+      break;
+    case 'multi':
+      output.outputs.forEach((o) => walkOutput(o, steps));
+      break;
+  }
+}
+
+export function generateCcwGuide(ir: LadderIR): CcwRungGuide[] {
+  return ir.rungs.map((rung: LadderRungIR) => {
+    const steps: CcwStep[] = [];
+    walkNetwork(rung.inputNetwork, steps);
+    walkOutput(rung.output, steps);
+    return { rungIndex: rung.index, comment: rung.comment, steps };
+  });
+}

--- a/src/services/ccw-guide-generator.ts
+++ b/src/services/ccw-guide-generator.ts
@@ -1,10 +1,26 @@
+/**
+ * CCW Guide Generator
+ *
+ * Converts a LadderIR into a sequence of step-by-step instructions for
+ * manually entering the equivalent program in Connected Components Workbench
+ * (CCW). Each rung becomes a CcwRungGuide whose steps describe which
+ * instructions to place and which tags to bind.
+ */
+
 // src/services/ccw-guide-generator.ts
 import type {
   LadderIR,
   LadderRungIR,
   ContactNetwork,
   RungOutput,
+  ContactType,
+  ComparatorOp,
+  CoilOutput,
 } from '../transformer/ladder-ir/ladder-ir-types';
+
+// ============================================================================
+// Public Types
+// ============================================================================
 
 export interface CcwStep {
   action: string;
@@ -16,14 +32,18 @@ export interface CcwRungGuide {
   steps: CcwStep[];
 }
 
-const CONTACT_LABELS: Record<string, string> = {
+// ============================================================================
+// Lookup Tables
+// ============================================================================
+
+const CONTACT_LABELS: Record<ContactType, string> = {
   NO: 'Direct Contact (XIC)',
   NC: 'Reverse Contact (XIO)',
   P: 'Positive Edge Contact',
   N: 'Negative Edge Contact',
 };
 
-const OP_LABELS: Record<string, string> = {
+const OP_LABELS: Record<ComparatorOp, string> = {
   EQ: 'EQU',
   NE: 'NEQ',
   GT: 'GRT',
@@ -32,11 +52,15 @@ const OP_LABELS: Record<string, string> = {
   LE: 'LEQ',
 };
 
-const COIL_LABELS: Record<string, string> = {
+const COIL_LABELS: Record<CoilOutput['coilType'], string> = {
   standard: 'Direct Coil (OTE)',
   set: 'Set Coil (OTL)',
   reset: 'Reset Coil (OTU)',
 };
+
+// ============================================================================
+// Network Walker
+// ============================================================================
 
 function walkNetwork(net: ContactNetwork, steps: CcwStep[]): void {
   switch (net.type) {
@@ -53,12 +77,12 @@ function walkNetwork(net: ContactNetwork, steps: CcwStep[]): void {
       break;
     case 'contact':
       steps.push({
-        action: `Add ${CONTACT_LABELS[net.contactType] ?? net.contactType} → bind to: ${net.variable}`,
+        action: `Add ${CONTACT_LABELS[net.contactType]} → bind to: ${net.variable}`,
       });
       break;
     case 'comparator':
       steps.push({
-        action: `Add ${OP_LABELS[net.operator] ?? net.operator} Instruction → Left: ${net.leftOperand}, Right: ${net.rightOperand}`,
+        action: `Add ${OP_LABELS[net.operator]} Instruction → Left: ${net.leftOperand}, Right: ${net.rightOperand}`,
       });
       break;
     case 'true':
@@ -66,17 +90,27 @@ function walkNetwork(net: ContactNetwork, steps: CcwStep[]): void {
         action: '(No contact needed — leave rung condition empty in CCW for unconditional execution)',
       });
       break;
+    default: {
+      const _exhaustive: never = net;
+      void _exhaustive;
+    }
   }
 }
+
+// ============================================================================
+// Output Walker
+// ============================================================================
 
 function walkOutput(output: RungOutput, steps: CcwStep[]): void {
   switch (output.type) {
     case 'coil':
       steps.push({
-        action: `Add ${COIL_LABELS[output.coilType] ?? output.coilType} → bind to: ${output.variable}`,
+        action: `Add ${COIL_LABELS[output.coilType]} → bind to: ${output.variable}`,
       });
       break;
     case 'timer':
+      // Note: TimerOutput.inputNetwork is NOT walked here because rung.inputNetwork
+      // was already walked at the rung level in generateCcwGuide.
       steps.push({
         action: `Add ${output.timerType} Function Block → instance name: ${output.instanceName}`,
       });
@@ -93,9 +127,24 @@ function walkOutput(output: RungOutput, steps: CcwStep[]): void {
     case 'multi':
       output.outputs.forEach((o) => walkOutput(o, steps));
       break;
+    default: {
+      const _exhaustive: never = output;
+      void _exhaustive;
+    }
   }
 }
 
+// ============================================================================
+// Public API
+// ============================================================================
+
+/**
+ * Generate a CCW entry guide from a LadderIR.
+ *
+ * @param ir - The compiled Ladder IR for a program.
+ * @returns An ordered array of per-rung guides, each containing the CCW steps
+ *          needed to reproduce that rung by hand.
+ */
 export function generateCcwGuide(ir: LadderIR): CcwRungGuide[] {
   return ir.rungs.map((rung: LadderRungIR) => {
     const steps: CcwStep[] = [];

--- a/src/services/ccw-guide-generator.ts
+++ b/src/services/ccw-guide-generator.ts
@@ -37,10 +37,10 @@ export interface CcwRungGuide {
 // ============================================================================
 
 const CONTACT_LABELS: Record<ContactType, string> = {
-  NO: 'Direct Contact (XIC)',
-  NC: 'Reverse Contact (XIO)',
-  P: 'Positive Edge Contact',
-  N: 'Negative Edge Contact',
+  NO: 'Examine If Closed (XIC)',
+  NC: 'Examine If Open (XIO)',
+  P: 'Positive Transition (XIC)',
+  N: 'Negative Transition (XIC)',
 };
 
 const OP_LABELS: Record<ComparatorOp, string> = {
@@ -53,9 +53,9 @@ const OP_LABELS: Record<ComparatorOp, string> = {
 };
 
 const COIL_LABELS: Record<CoilOutput['coilType'], string> = {
-  standard: 'Direct Coil (OTE)',
-  set: 'Set Coil (OTL)',
-  reset: 'Reset Coil (OTU)',
+  standard: 'Output Energize (OTE)',
+  set: 'Output Latch (OTL)',
+  reset: 'Output Unlatch (OTU)',
 };
 
 // ============================================================================

--- a/src/services/live-bridge.ts
+++ b/src/services/live-bridge.ts
@@ -1,0 +1,150 @@
+/**
+ * Live PLC Data Bridge
+ *
+ * Polls the Jarvis Node (/jarvis/shell) via HTTP to read Modbus coil/register
+ * values from the Micro 820 PLC at 192.168.1.100, then injects them into the
+ * simulation store via setVariables(). Only IN-direction variables are read
+ * (never stomp on PLC outputs).
+ *
+ * Address format in manifest: "COIL:N" (1-indexed) or "HR:N"
+ * pymodbus register addressing is 0-indexed, so we subtract 1.
+ */
+
+export interface LiveBridgeTarget {
+  name: string;
+  addressType: 'coil' | 'holding';
+  register: number; // 0-indexed for pymodbus
+}
+
+export interface LiveBridgeCallbacks {
+  onValues: (values: Record<string, boolean | number>) => void;
+  onStatus: (status: 'connecting' | 'live' | 'error', error?: string) => void;
+}
+
+// ============================================================================
+// Address Parser
+// ============================================================================
+
+export function parseAddress(addr: string): { type: 'coil' | 'holding'; register: number } | null {
+  if (!addr) return null;
+  const upper = addr.toUpperCase();
+
+  const coilMatch = upper.match(/^COIL:(\d+)$/);
+  if (coilMatch) return { type: 'coil', register: parseInt(coilMatch[1], 10) - 1 };
+
+  const hrMatch = upper.match(/^HR:(\d+)$/);
+  if (hrMatch) return { type: 'holding', register: parseInt(hrMatch[1], 10) - 1 };
+
+  return null;
+}
+
+// ============================================================================
+// Python Command Builder
+// ============================================================================
+
+function buildPymodbusCommand(targets: LiveBridgeTarget[], plcHost: string, plcPort: number): string {
+  const coils = targets.filter((t) => t.addressType === 'coil');
+  const holdings = targets.filter((t) => t.addressType === 'holding');
+
+  const coilReads = coils.map(
+    (t) => `{"name":"${t.name}","type":"coil","reg":${t.register},"val":c.read_coils(${t.register},1).bits[0] if c.read_coils(${t.register},1) else None}`
+  );
+  const hrReads = holdings.map(
+    (t) => `{"name":"${t.name}","type":"hr","reg":${t.register},"val":c.read_holding_registers(${t.register},1).registers[0] if c.read_holding_registers(${t.register},1) else None}`
+  );
+  const allReads = [...coilReads, ...hrReads].join(',');
+
+  return [
+    `from pymodbus.client import ModbusTcpClient`,
+    `import json`,
+    `c = ModbusTcpClient("${plcHost}", port=${plcPort})`,
+    `c.connect()`,
+    `results = [${allReads}]`,
+    `c.close()`,
+    `print(json.dumps([r for r in results if r["val"] is not None]))`,
+  ].join('; ');
+}
+
+// ============================================================================
+// Response Parser
+// ============================================================================
+
+function parseJarvisResponse(stdout: string, targets: LiveBridgeTarget[]): Record<string, boolean | number> {
+  const results: Record<string, boolean | number> = {};
+  try {
+    const rows: Array<{ name: string; type: string; val: boolean | number }> = JSON.parse(stdout.trim());
+    for (const row of rows) {
+      if (row.name && row.val !== null && row.val !== undefined) {
+        results[row.name] = row.type === 'coil' ? Boolean(row.val) : Number(row.val);
+      }
+    }
+  } catch {
+    // ignore parse errors — caller will see empty results
+  }
+  return results;
+}
+
+// ============================================================================
+// Bridge Lifecycle
+// ============================================================================
+
+export interface LiveBridgeConfig {
+  plcHost?: string;
+  plcPort?: number;
+  pollIntervalMs?: number;
+}
+
+export function startLiveBridge(
+  targets: LiveBridgeTarget[],
+  callbacks: LiveBridgeCallbacks,
+  config: LiveBridgeConfig = {}
+): () => void {
+  const { plcHost = '192.168.1.100', plcPort = 502, pollIntervalMs = 300 } = config;
+
+  if (targets.length === 0) {
+    callbacks.onStatus('error', 'No variables with Modbus addresses to poll');
+    return () => {};
+  }
+
+  let stopped = false;
+  let firstSuccess = false;
+  const cmd = buildPymodbusCommand(targets, plcHost, plcPort);
+
+  const poll = async () => {
+    if (stopped) return;
+
+    try {
+      const res = await fetch('/jarvis/shell', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ command: `python3 -c "${cmd.replace(/"/g, '\\"')}"`, timeout: 5 }),
+      });
+
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+      const body = await res.json() as { stdout?: string; stderr?: string; exitCode?: number };
+      const values = parseJarvisResponse(body.stdout ?? '', targets);
+
+      if (!firstSuccess) {
+        firstSuccess = true;
+        callbacks.onStatus('live');
+      }
+
+      if (Object.keys(values).length > 0) {
+        callbacks.onValues(values);
+      }
+    } catch (err) {
+      callbacks.onStatus('error', err instanceof Error ? err.message : 'Connection failed');
+      firstSuccess = false;
+    }
+
+    if (!stopped) {
+      setTimeout(poll, pollIntervalMs);
+    }
+  };
+
+  callbacks.onStatus('connecting');
+  poll();
+
+  return () => { stopped = true; };
+}

--- a/src/services/manifest-loader.ts
+++ b/src/services/manifest-loader.ts
@@ -34,6 +34,6 @@ export async function loadManifest(url: string): Promise<VariableManifest> {
 // Summarize gaps for display in the PDF Gaps section.
 export function formatGaps(manifest: VariableManifest): string[] {
   return manifest.gaps.map(
-    (g) => 
+    (g) => `${g.variableName}: missing ${g.missingFields.join(', ')}${g.note ? ` — ${g.note}` : ''}`
   );
 }

--- a/src/services/manifest-loader.ts
+++ b/src/services/manifest-loader.ts
@@ -1,0 +1,39 @@
+import type { VariableManifest, VariableDeclaration } from "../models/plc-types";
+
+// Merge manifest variables into editor VariableDeclarations.
+// Fields already set in the editor declaration take precedence;
+// manifest fills in missing alias/address/wiring metadata.
+export function mergeManifest(
+  declarations: VariableDeclaration[],
+  manifest: VariableManifest
+): VariableDeclaration[] {
+  const byName = new Map(manifest.variables.map((v) => [v.name, v]));
+
+  return declarations.map((decl) => {
+    const m = byName.get(decl.name);
+    if (!m) return decl;
+    return {
+      ...decl,
+      alias: decl.alias ?? m.alias,
+      modbusAddress: decl.modbusAddress ?? m.modbusAddress,
+      retain: decl.retain ?? m.retain,
+      terminalLabel: decl.terminalLabel ?? m.terminalLabel,
+      sourceDevice: decl.sourceDevice ?? m.sourceDevice,
+      direction: decl.direction ?? m.direction,
+    };
+  });
+}
+
+// Load a manifest JSON file from a URL or path (browser fetch).
+export async function loadManifest(url: string): Promise<VariableManifest> {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error();
+  return res.json() as Promise<VariableManifest>;
+}
+
+// Summarize gaps for display in the PDF Gaps section.
+export function formatGaps(manifest: VariableManifest): string[] {
+  return manifest.gaps.map(
+    (g) => 
+  );
+}

--- a/src/store/editor-store.ts
+++ b/src/store/editor-store.ts
@@ -51,13 +51,36 @@ interface EditorState {
 // Default Templates
 // ============================================================================
 
-const BLANK_TEMPLATE = `PROGRAM Main
-VAR
-  // Declare variables here
+const BLANK_TEMPLATE = `PROGRAM ConveyorPhase1
+VAR_INPUT
+    DI_02 : BOOL;
+    DI_00 : BOOL;
+    DI_01 : BOOL;
 END_VAR
-
-  // Write your ladder logic here
-
+VAR_OUTPUT
+    DO_02 : BOOL;
+    dir_fwd : BOOL;
+    dir_rev : BOOL;
+END_VAR
+VAR
+    e_stop_active : BOOL;
+    vfd_cmd : INT;
+    vfd_freq : INT;
+    poll_timer : TON;
+END_VAR
+e_stop_active := NOT DI_02;
+DO_02 := NOT e_stop_active;
+dir_fwd := DI_00 AND NOT DI_01;
+dir_rev := NOT DI_00 AND DI_01;
+IF dir_fwd AND NOT e_stop_active THEN
+    vfd_cmd := 18;
+ELSIF dir_rev AND NOT e_stop_active THEN
+    vfd_cmd := 20;
+ELSE
+    vfd_cmd := 1;
+END_IF;
+vfd_freq := 300;
+poll_timer(IN := NOT poll_timer.Q, PT := T#500ms);
 END_PROGRAM
 `;
 

--- a/src/store/project-store.ts
+++ b/src/store/project-store.ts
@@ -23,11 +23,21 @@ import { loadFromLocalStorage } from '../services/file-service';
 // State Interface
 // ============================================================================
 
+export interface ManifestEntry {
+  alias?: string;
+  modbusAddress?: string;
+  direction?: 'IN' | 'OUT';
+  address?: string;
+}
+
 interface ProjectState {
   // Project data
   project: LadderProject | null;
   currentProgramId: string | null;
   isDirty: boolean;
+
+  // Manifest metadata: keyed by variable name, populated by loadManifest
+  manifestMetadata: Record<string, ManifestEntry>;
 
   // File state
   filePath: string | null;
@@ -62,6 +72,7 @@ interface ProjectState {
   addGlobalVariable: (variable: VariableDeclaration) => void;
   updateGlobalVariable: (name: string, variable: Partial<VariableDeclaration>) => void;
   removeGlobalVariable: (name: string) => void;
+  loadManifest: (manifest: { variables: Array<{ name: string; alias?: string | null; modbusAddress?: string | null; direction?: 'IN' | 'OUT'; address?: string | null }> }) => void;
 
   // Configuration actions
   setConfiguration: (config: ProjectConfiguration) => void;
@@ -77,6 +88,7 @@ export const useProjectStore = create<ProjectState>()(
     project: null,
     currentProgramId: null,
     isDirty: false,
+    manifestMetadata: {},
     filePath: null,
     lastTransformResult: null,
     transformedNodes: [],
@@ -344,6 +356,19 @@ export const useProjectStore = create<ProjectState>()(
         },
         isDirty: true,
       });
+    },
+
+    loadManifest: (manifest) => {
+      const metadata: Record<string, ManifestEntry> = {};
+      for (const entry of manifest.variables) {
+        metadata[entry.name] = {
+          ...(entry.alias != null && { alias: entry.alias }),
+          ...(entry.modbusAddress != null && { modbusAddress: entry.modbusAddress }),
+          ...(entry.direction != null && { direction: entry.direction }),
+          ...(entry.address != null && { address: entry.address }),
+        };
+      }
+      set({ manifestMetadata: metadata });
     },
 
     // Configuration

--- a/src/store/simulation-store.ts
+++ b/src/store/simulation-store.ts
@@ -146,6 +146,11 @@ interface SimulationState {
   // Bulk operations
   setVariables: (vars: Record<string, boolean | number>) => void;
   clearAll: () => void;
+
+  // Power flow animation
+  poweredNodeIds: Set<string>;
+  poweredEdgeIds: Set<string>;
+  setPowerFlow: (nodeIds: Set<string>, edgeIds: Set<string>) => void;
 }
 
 // ============================================================================
@@ -226,6 +231,8 @@ export const useSimulationStore = create<SimulationState>()(
     counters: {},
     edgeDetectors: {},
     bistables: {},
+    poweredNodeIds: new Set<string>(),
+    poweredEdgeIds: new Set<string>(),
 
     // Control actions
     start: () => set({ status: 'running' }),
@@ -249,7 +256,13 @@ export const useSimulationStore = create<SimulationState>()(
         counters: {},
         edgeDetectors: {},
         bistables: {},
+        poweredNodeIds: new Set<string>(),
+        poweredEdgeIds: new Set<string>(),
       });
+    },
+
+    setPowerFlow: (nodeIds: Set<string>, edgeIds: Set<string>) => {
+      set({ poweredNodeIds: nodeIds, poweredEdgeIds: edgeIds });
     },
 
     step: () => {

--- a/src/transformer/ladder-ir/ladder-ir-types.ts
+++ b/src/transformer/ladder-ir/ladder-ir-types.ts
@@ -76,6 +76,7 @@ export interface ContactElement {
   contactType: ContactType;
   /** Reference back to source AST for roundtrip */
   sourceExpr?: STExpression;
+  nodeId?: string;
 }
 
 export type ComparatorOp = 'EQ' | 'NE' | 'GT' | 'GE' | 'LT' | 'LE';
@@ -86,6 +87,7 @@ export interface ComparatorElement {
   leftOperand: string;
   rightOperand: string;
   sourceExpr?: STExpression;
+  nodeId?: string;
 }
 
 /**
@@ -109,6 +111,7 @@ export interface CoilOutput {
   type: 'coil';
   variable: string;
   coilType: 'standard' | 'set' | 'reset';
+  nodeId?: string;
 }
 
 export type TimerType = 'TON' | 'TOF' | 'TP';
@@ -120,6 +123,7 @@ export interface TimerOutput {
   presetTime: string; // e.g., "T#5s"
   /** The input network that drives the timer's IN pin */
   inputNetwork: ContactNetwork;
+  nodeId?: string;
 }
 
 export type CounterType = 'CTU' | 'CTD' | 'CTUD';
@@ -131,6 +135,7 @@ export interface CounterOutput {
   presetValue: number;
   /** The input network that drives the counter's CU/CD pin */
   inputNetwork: ContactNetwork;
+  nodeId?: string;
 }
 
 /**

--- a/src/transformer/layout/rung-layout.ts
+++ b/src/transformer/layout/rung-layout.ts
@@ -115,6 +115,8 @@ export interface RungLayout {
   edges: LayoutEdge[];
   width: number;
   height: number;
+  leftRailId: string;
+  rightRailId: string;
 }
 
 // ============================================================================
@@ -223,7 +225,7 @@ export function layoutRung(rung: LadderRungIR, baseY: number): RungLayout {
   leftRail.height = totalHeight;
   rightRail.height = totalHeight;
 
-  return { nodes, edges, width: totalWidth, height: totalHeight };
+  return { nodes, edges, width: totalWidth, height: totalHeight, leftRailId, rightRailId };
 }
 
 // ============================================================================
@@ -270,6 +272,7 @@ function layoutSingleContact(
   rungIndex: number
 ): NetworkLayoutResult {
   const id = generateNodeId(rungId);
+  contact.nodeId = id;
   const node: LayoutNode = {
     id,
     x,
@@ -402,6 +405,7 @@ function layoutComparator(
   rungIndex: number
 ): NetworkLayoutResult {
   const id = generateNodeId(rungId);
+  comparator.nodeId = id;
   const node: LayoutNode = {
     id,
     x,
@@ -508,6 +512,7 @@ function layoutCoil(
   rungIndex: number
 ): OutputLayoutResult {
   const id = generateNodeId(rungId);
+  coil.nodeId = id;
   const node: LayoutNode = {
     id,
     x,
@@ -533,6 +538,7 @@ function layoutTimer(
   rungIndex: number
 ): OutputLayoutResult {
   const id = generateNodeId(rungId);
+  timer.nodeId = id;
   const node: LayoutNode = {
     id,
     x,
@@ -559,6 +565,7 @@ function layoutCounter(
   rungIndex: number
 ): OutputLayoutResult {
   const id = generateNodeId(rungId);
+  counter.nodeId = id;
   const node: LayoutNode = {
     id,
     x,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,15 @@ import tailwindcss from '@tailwindcss/vite'
 export default defineConfig({
   base: '/',
   plugins: [react(), tailwindcss()],
+  server: {
+    proxy: {
+      '/jarvis': {
+        target: 'http://100.72.2.99:8765',
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/jarvis/, ''),
+      },
+    },
+  },
   resolve: {
     alias: {
       '@': path.resolve(__dirname, './src'),


### PR DESCRIPTION
## Summary

Three features shipped on this branch, all running on Mikecranesync/main:

### 1. AB-style variable table (this PR's original scope)
- **BOOL/NUM tabs** render as Allen-Bradley / CCW-style tables: Name | Alias | AT Addr | Modbus | Dir | Value
- **Manifest toolbar button** (📋) loads a JSON file → populates alias, address, Modbus, direction for any variable by name
- **`manifestMetadata`** flat record in project store — independent of program variable declarations, works for ST-loaded files
- **ContactNode / CoilNode** display alias as italic 8px second line below variable name

### 2. Power flow animation (shipped 2026-05-10, commit `77e69ad`)
- After each 100ms scan cycle, `evaluatePowerFlow()` walks LadderIR contact networks
- Powered nodes get `.powered` CSS class (green border / rail glow via `--color-success`)
- Powered edges get green 3px stroke
- All 6 node types subscribe: ContactNode, CoilNode, TimerNode, CounterNode, ComparatorNode, PowerRailNode
- Clears immediately on Stop
- New file: `src/interpreter/power-flow-evaluator.ts`

### 3. Live PLC data bridge (shipped 2026-05-10, commit `95a3e91`)
- 📡 toolbar button polls Jarvis Node `/shell` with pymodbus one-liners (300ms interval)
- Reads `COIL:N` / `HR:N` manifest addresses — IN-direction variables only, never stomps outputs
- Injects values into simulation store via `setVariables()` → combined with power flow = real hardware lighting up the diagram
- Vite proxy: `/jarvis/*` → `http://100.72.2.99:8765` for CORS-free dev
- Status: 📡 off → 🟡 connecting → 🔴 Live ● → ⚠️ Error
- New files: `src/services/live-bridge.ts`, `src/hooks/useLiveBridge.ts`

## Bug fixes (pre-existing)
- `src/services/manifest-loader.ts` line 38: empty arrow function body (esbuild syntax error)
- `src/components/wiring-diagram/WiringDiagram.tsx`: empty `viewBox={}`, `points={}`, `transform={}` JSX expressions

## Test plan

**AB-style table:**
- [ ] Load any ST file → BOOL/NUM tabs show `—` for all metadata columns
- [ ] Click Manifest, load matching JSON → alias, address, Modbus, direction columns populate
- [ ] Variables not in manifest still show `—` (no crash)
- [ ] Rung contact/coil nodes show alias as italic second line after manifest load

**Power flow:**
- [ ] Click Run → contact nodes glow green when their variable is TRUE, coil glows when rung energized
- [ ] Left power rail always green when running
- [ ] NC contact glows green when variable is FALSE (inverted logic correct)
- [ ] Click Stop → all nodes return to default color immediately

**Live bridge:**
- [ ] Click Live with no manifest → shows ⚠️ Error with message "No IN variables with Modbus addresses"
- [ ] Load manifest with COIL: addresses, click Live → 🟡 connecting → 🔴 Live ●
- [ ] PLC I/O changes appear in variable watch within 300ms

**Build:**
- [ ] `npm test` — passing
- [ ] `npm run build` — clean TypeScript, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)